### PR TITLE
Add govuk elements form builder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'haml-rails', '~> 0.9'
 gem 'govuk_template'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_elements_rails'
-gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
+gem 'govuk_elements_form_builder', git: 'https://github.com/danmitchell-/govuk_elements_form_builder'
 
 # Ruby client for OpenRegisters
 gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'haml-rails', '~> 0.9'
 gem 'govuk_template'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_elements_rails'
+gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
 
 # Ruby client for OpenRegisters
 gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: f5c4588193fdd2b15ba4088de62a4ebc100e277c
+  remote: https://github.com/danmitchell-/govuk_elements_form_builder
+  revision: 7d1f52dce18e7ffcdeaf1bbc0c0a4183f592f3f8
   specs:
     govuk_elements_form_builder (0.0.4)
       rails (>= 4.2)
@@ -88,8 +88,8 @@ GEM
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
     ffi (1.9.18)
-    globalid (0.3.7)
-      activesupport (>= 4.1.0)
+    globalid (0.4.0)
+      activesupport (>= 4.2.0)
     govuk_elements_rails (3.0.1)
       govuk_frontend_toolkit (>= 5.0.2)
       rails (>= 4.1.0)
@@ -242,7 +242,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.6)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.1.4)
       execjs (>= 0.3.0, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
+  revision: f5c4588193fdd2b15ba4088de62a4ebc100e277c
+  specs:
+    govuk_elements_form_builder (0.0.4)
+      rails (>= 4.2)
+
+GIT
   remote: https://github.com/openregister/openregister-ruby
   revision: b3f28f9f1feb0ebf23870a52e04d62867ea980f2
   specs:
@@ -264,6 +271,7 @@ DEPENDENCIES
   database_cleaner
   devise
   factory_girl_rails
+  govuk_elements_form_builder!
   govuk_elements_rails
   govuk_frontend_toolkit
   govuk_notify_rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,10 @@ a:visited {
   color: $grey-2;
 }
 
+.form-label {
+  font-weight: bold;
+}
+
 table {
   margin-bottom: 20px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,11 @@ table th {
   font-size: 16px;
 }
 
+// Hide legend in fieldsets in favour of headings
+.form-group fieldset legend {
+  display: none;
+}
+
 // Override purple colour
 a:visited {
   color: $govuk-blue;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,13 +3,13 @@ class HomeController < ApplicationController
   end
 
   def select_register
-    if params[:register] == "countries"
+    if params[:register][:register] == "country"
       redirect_to countries_path
-    elsif params[:register] == "territories"
+    elsif params[:register][:register] == "territory"
       redirect_to territories_path
-    elsif params[:register] == "local_authority_engs"
+    elsif params[:register][:register] == "local_authority_eng"
       redirect_to local_authority_engs_path
-    elsif params[:register] == "local_authority_types"
+    elsif params[:register][:register] == "local_authority_type"
       redirect_to local_authority_types_path
     else
       redirect_to root_path

--- a/app/views/countries/steps/_page1.html.haml
+++ b/app/views/countries/steps/_page1.html.haml
@@ -3,27 +3,9 @@
 - else
   %h1.heading-large Add a new country
 
-.form-group
-  = f.label :code, "Country", class: "form-label form-label-bold"
-  %span.form-hint The country's 2-letter ISO 3166-2 alpha code
-  = f.text_field :code, readonly: @country.persisted?, class: "form-control form-control-1-8 #{@country.persisted? ? 'disabled' : ''}"
-.form-group
-  = f.label :name, class: "form-label form-label-bold"
-  %span.form-hint The commonly used name for this record
-  = f.text_field :name, class: "form-control"
-.form-group
-  = f.label :official_name, class: "form-label form-label-bold"
-  %span.form-hint The official or technical name for this record
-  = f.text_field :official_name, class: "form-control"
-.form-group
-  = f.label :citizen_name, class: "form-label form-label-bold"
-  %span.form-hint The name of the country's citizens
-  = f.text_field :citizen_name, class: "form-control"
-.form-group
-  = f.label :start_date, class: "form-label form-label-bold"
-  %span.form-hint The date a record first became relevant to a register
-  = f.text_field :start_date, class: "form-control"
-.form-group
-  = f.label :end_date, class: "form-label form-label-bold"
-  %span.form-hint The date a record stopped being applicable to a register
-  = f.text_field :end_date, class: "form-control"
+= f.text_field :code, readonly: @country.persisted?, class: "form-control-1-8 #{@country.persisted? ? 'disabled' : ''}"
+= f.text_field :name
+= f.text_field :official_name
+= f.text_field :citizen_name
+= f.text_field :start_date
+= f.text_field :end_date

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -4,29 +4,13 @@
 
 %h5.heading-medium Choose a register
 
-= form_tag select_register_path do
-  .form-group
-    %fieldset
-      %legend.visually-hidden Choose a register
-      - unless current_user.email == "stephen.mcallister@communities.gsi.gov.uk"
-        .multiple-choice
-          = radio_button_tag :register, "countries"
-          = label_tag "register_country", "Country"
-        .multiple-choice
-          = radio_button_tag :register, "territories"
-          = label_tag "register_territory", "Territory"
-      - unless current_user.email == "tony.worron@fco.gsi.gov.uk"
-        .multiple-choice
-          = radio_button_tag :register, "local_authority_types"
-          = label_tag "register_local_authority_type", "Local Authority Type"
-        .multiple-choice
-          = radio_button_tag :register, "local_authority_engs"
-          = label_tag "register_local_authority_eng", "Local Authority Eng"
+= form_for "register", url: select_register_path do |f|
+  = f.radio_button_fieldset :register, choices: ["country", "territory", "local_authority_type", "local_authority_eng"]
   .form-group
     = submit_tag "Continue", class: "button"
 
 - content_for :javascript do
   :javascript
     jQuery(function($) {
-      $("input[name='register']:first").attr("checked", true)
+      $("input[name='register[register]']:first").attr("checked", true)
     });

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module CustodianUpdateTool
     # -- all .rb files in that directory are automatically loaded.
 
     config.active_job.queue_adapter = :sidekiq
+
+    ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,20 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  helpers:
+    label:
+      country:
+        code: Country
+        name: Name
+        official_name: Official name
+        citizen_name: Citizen name
+        start_date: Start date
+        end_date: End date
+    hint:
+      country:
+        code: "The country's 2-letter ISO 3166-2 alpha code"
+        name: The commonly used name for this record
+        official_name: The official or technical name for this record
+        citizen_name: "The name of the country's citizens"
+        start_date: The date a record first became relevant to a register
+        end_date: The date a record stopped being applicable to a register


### PR DESCRIPTION
Added the `govuk_elements_form_builder` gem to refactor our forms and clean up our views.

Just done it for countries as an example of how it can work.

Using my fork as it supports the new radio buttons from gov_uk_elements and the main repo doesn't yet. (PR has been raised.)