### PR TITLE
Add password validation for min length

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,11 @@ a[data-method='delete'] {
   color: $error-colour;
 }
 
+// Hide hint text because the form_builder gem doesnt support this
+.no-hint .form-hint {
+  display: none;
+}
+
 .inline-link {
   background: none;
   border: none;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :teams, through: :team_members
 
   validates :full_name, presence: true
+  validates :password, length: { minimum: 8 }
 
   accepts_nested_attributes_for :team_members
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,7 +3,7 @@
 %h1.heading-xlarge Sign in
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   = f.email_field :email
-  = f.password_field :password
+  = f.password_field :password, { label_options: { class: 'no-hint' } }
   .form-group
     = f.submit "Continue", class: "button"
 = render "devise/shared/links"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,3 +17,7 @@ en:
       title: Role
       change_role: Change permission
       heading: Select permission
+  helpers:
+    hint:
+      user:
+        password: At least 8 characters


### PR DESCRIPTION
The form builder enables us to add hint text as locales however this
means that every password field on the user model will get the hint
text but we don’t want it on the sign in form so its being hidden with
CSS