### PR TITLE
Fix team view for admin users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,12 +10,18 @@ class UsersController < ApplicationController
   end
 
   def team
+    if params[:team_id].present?
+      team_id = params[:team_id]
+    else
+      team_id = team_id_for_high_permissions(current_user)
+    end
+
     @basic_users = User.joins(:team_members)
-                       .where(team_members: { team_id: team_id_for_high_permissions(current_user) })
+                       .where(team_members: { team_id: team_id })
                        .where(team_members: { role: 'basic' })
 
     @advanced_users = User.joins(:team_members)
-                          .where(team_members: { team_id: team_id_for_high_permissions(current_user) })
+                          .where(team_members: { team_id: team_id })
                           .where(team_members: { role: 'advanced' })
   end
 

--- a/app/views/users/custodians.html.haml
+++ b/app/views/users/custodians.html.haml
@@ -25,4 +25,4 @@
           - custodian.team_members.first.team.registers.each do |register|
             %span.user__register-name= register
         %td
-          = link_to "View team", "#"
+          = link_to "View team", team_path(team_id: custodian.team_members.first.team_id)


### PR DESCRIPTION
This PR is to scope the `team` view to one group of register managers at a time when the `current_user` is `admin` because the page is scoped by default to the non admin current_users team anyway.