### PR TITLE
Refactor admin user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,10 +16,11 @@ class ApplicationController < ActionController::Base
   protected
 
   def devise_configure_permitted_parameters
-    devise_parameter_sanitizer.permit :accept_invitation, keys: [:full_name, :password, :password_confirmation]
-    devise_parameter_sanitizer.permit :sign_up, keys: [:full_name, :email, :password, :password_confirmation]
-    devise_parameter_sanitizer.permit :sign_in, keys: [:full_name, :email, :password]
-    devise_parameter_sanitizer.permit :account_update, keys: [:full_name, :email, :password, :password_confirmation, :current_password, :registers]
+    devise_parameter_sanitizer.permit :invite, keys: [:email, :admin]
+    devise_parameter_sanitizer.permit :accept_invitation, keys: [:full_name, :password, :password_confirmation, :admin]
+    devise_parameter_sanitizer.permit :sign_up, keys: [:full_name, :email, :password, :password_confirmation, :admin]
+    devise_parameter_sanitizer.permit :sign_in, keys: [:full_name, :email, :password, :admin]
+    devise_parameter_sanitizer.permit :account_update, keys: [:full_name, :email, :password, :password_confirmation, :current_password, :registers, :admin]
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,12 +4,10 @@ class UsersController < ApplicationController
   before_action :set_user
 
   def admin
-    @admin_users = User.joins(:team_members)
-                       .where(team_members: { role: 'admin' })
+    @admin_users = User.where(admin: true)
                        .where.not(invitation_accepted_at: nil)
 
-    @pending_users = User.joins(:team_members)
-                         .where(team_members: { role: 'admin' })
+    @pending_users = User.where(admin: true)
                          .where(invitation_accepted_at: nil)
 
     authorize! :admin, @users
@@ -46,7 +44,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:full_name, :email, :role, :password, :password_confirmation, :current_password, team_members_attributes: [:role])
+    params.require(:user).permit(:full_name, :email, :role, :admin, :password, :password_confirmation, :current_password, team_members_attributes: [:role])
   end
 
 end
@@ -63,29 +61,31 @@ class UsersController::InvitationsController < Devise::InvitationsController
 
     user = User.find_by_email(resource_params[:email])
 
-    if current_user.admin?
-      if params[:user][:role] == 'custodian'
-        registers = Array.new
+    unless user.admin?
+      if current_user.admin?
+        if params[:user][:role] == 'custodian'
+          registers = Array.new
 
-        loop.with_index{|_, i|
-          register_name = resource_params[:teams_attributes][i.to_s][:registers]
+          loop.with_index{|_, i|
+            register_name = resource_params[:teams_attributes][i.to_s][:registers]
 
-          unless register_name.nil?
-            registers.push(register_name)
-          end
-          break if resource_params[:teams_attributes][(i + 1).to_s].nil?
-        }
+            unless register_name.nil?
+              registers.push(register_name)
+            end
+            break if resource_params[:teams_attributes][(i + 1).to_s].nil?
+          }
 
-        registers = registers.uniq
-        team = Team.new(registers: registers)
-        user.team_members.create(role: params[:user][:role], team: team).save
+          registers = registers.uniq
+          team = Team.new(registers: registers)
+          user.team_members.create(role: params[:user][:role], team: team).save
+        else
+          user.team_members.create(role: params[:user][:role]).save
+        end
       else
-        user.team_members.create(role: params[:user][:role]).save
+        # update team_members because the invite save only saves user
+        user.team_members.create(team_id: resource_params[:team_members_attributes]['0'][:team_id],
+                                 role: resource_params[:team_members_attributes]['0'][:role]).save
       end
-    else
-      # update team_members because the invite save only saves user
-      user.team_members.create(team_id: resource_params[:team_members_attributes]['0'][:team_id],
-                               role: resource_params[:team_members_attributes]['0'][:role]).save
     end
 
     # send email with injected params

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -24,28 +24,26 @@ class DeviseMailer < Devise::Mailer
   end
 
   def invitation_instructions(record, token, opts={})
-    case record.team_members.last.role
-
-    when 'admin'
+    if record.admin?
       set_template(Rails.application.secrets.notify_admin_invite_template)
       set_personalisation(
         current_user_full_name: User.find(record.invited_by_id).full_name,
         invite_url: accept_invitation_url(record, invitation_token: token)
       )
+    else
+      if record.team_members.last.role == 'custodian'
+        set_template(Rails.application.secrets.notify_custodian_invite_template)
+        set_standard_personalisations(record, token)
 
-    when 'custodian'
-      set_template(Rails.application.secrets.notify_custodian_invite_template)
-      set_standard_personalisations(record, token)
+      elsif record.team_members.last.role == 'advanced'
+        set_template(Rails.application.secrets.notify_advanced_invite_template)
+        set_standard_personalisations(record, token)
 
-    when 'advanced'
-      set_template(Rails.application.secrets.notify_advanced_invite_template)
-      set_standard_personalisations(record, token)
-
-    when 'basic'
-      set_template(Rails.application.secrets.notify_basic_invite_template)
-      set_standard_personalisations(record, token)
+      elsif record.team_members.last.role == 'basic'
+        set_template(Rails.application.secrets.notify_basic_invite_template)
+        set_standard_personalisations(record, token)
+      end
     end
-
     mail(to: record.email)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,23 +13,19 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 8 }
 
   def role
-    team_members.first.role
-  end
-
-  def admin?
-    team_members.first.role == 'admin'
+    team_members.first.try(:role)
   end
 
   def custodian?
-    team_members.first.role == 'custodian'
+    team_members.first.try(:role) == 'custodian'
   end
 
   def advanced?
-    team_members.first.role == 'advanced'
+    team_members.first.try(:role) == 'advanced'
   end
 
   def basic?
-    team_members.first.role == 'basic'
+    team_members.first.try(:role) == 'basic'
   end
 
 end

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -9,44 +9,47 @@
       %div.column-full
         = f.text_field field
 
-  - if current_user.admin?
-    .form-group
-      = f.hidden_field :role, value: params[:role]
-      - if params[:role] == 'custodian'
-        = f.label :registers, class: "form-label"
-        = f.nested_fields_for :teams, f.object.teams.new do |team|
-          %div.grid-row.form-group
-            %div.column-one-half
-              = team.select :registers, beta_registers_by_name.collect{ |r| [prepare_register_name(r), r]}, {include_blank: "", multiple: true }, { class: "form-control autocomplete" }
-            %div.column-one-half
-              = team.remove_nested_fields_link 'Remove register'
-
-        = f.add_nested_fields_link :teams, 'Add register'
-
+  - if params[:role] == 'admin'
+    = f.hidden_field :admin, value: true
   - else
-    =f.fields_for :team_members, TeamMember.new do |tm|
-      =tm.hidden_field :team_id, value: params[:team_id]
-      %h3.heading-small= t('views.users.permission_title')
+    - if current_user.admin?
       .form-group
-        %fieldset
-          %legend.visually-hidden= t('views.users.role')
-          .multiple-choice
-            = tm.radio_button :role, "advanced"
-            = tm.label :role, "Advanced", value: "advanced"
-          .user__permissions
-            %p.list-title Advanced can:
-            %ul.list.list-bullet
-              %li Change records
-              %li Submit changes for review
-              %li Approve and publish changes to records
-          .multiple-choice
-            = tm.radio_button :role, "basic"
-            = tm.label :role, "Basic", value: "basic"
-          .user__permissions
-            %p.list-title Basic can:
-            %ul.list.list-bullet
-              %li Change records
-              %li Submit changes for review
+        = f.hidden_field :role, value: params[:role]
+        - if params[:role] == 'custodian'
+          = f.label :registers, class: "form-label"
+          = f.nested_fields_for :teams, f.object.teams.new do |team|
+            %div.grid-row.form-group
+              %div.column-one-half
+                = team.select :registers, beta_registers_by_name.collect{ |r| [prepare_register_name(r), r]}, {include_blank: "", multiple: true }, { class: "form-control autocomplete" }
+              %div.column-one-half
+                = team.remove_nested_fields_link 'Remove register'
+
+          = f.add_nested_fields_link :teams, 'Add register'
+
+    - else
+      = f.fields_for :team_members, TeamMember.new do |tm|
+        = tm.hidden_field :team_id, value: params[:team_id]
+        %h3.heading-small= t('views.users.permission_title')
+        .form-group
+          %fieldset
+            %legend.visually-hidden= t('views.users.role')
+            .multiple-choice
+              = tm.radio_button :role, "advanced"
+              = tm.label :role, "Advanced", value: "advanced"
+            .user__permissions
+              %p.list-title Advanced can:
+              %ul.list.list-bullet
+                %li Change records
+                %li Submit changes for review
+                %li Approve and publish changes to records
+            .multiple-choice
+              = tm.radio_button :role, "basic"
+              = tm.label :role, "Basic", value: "basic"
+            .user__permissions
+              %p.list-title Basic can:
+              %ul.list.list-bullet
+                %li Change records
+                %li Submit changes for review
 
   .form-group
     = f.submit "Send invite", class: 'button'

--- a/db/migrate/20170622164850_add_admin_to_users.rb
+++ b/db/migrate/20170622164850_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170612142852) do
+ActiveRecord::Schema.define(version: 20170622164850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,18 +50,18 @@ ActiveRecord::Schema.define(version: 20170612142852) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.string   "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 20170612142852) do
     t.integer  "invited_by_id"
     t.integer  "invitations_count",      default: 0
     t.string   "full_name"
+    t.boolean  "admin",                  default: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["full_name"], name: "index_users_on_full_name", unique: true, using: :btree
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,8 @@ user1 = User.create(
   full_name: 'Admin',
   password: 'password123',
   password_confirmation: 'password123',
-  invitation_accepted_at: Date.today
+  invitation_accepted_at: Date.today,
+  admin: true
 )
 user2 = User.create(
   email: 'tony.worron@fco.gsi.gov.uk',


### PR DESCRIPTION
This change removes the team_members model from users defined as admin
because they aren’t a team in the same was as other users