### PR TITLE
Don't send register_update_notification if no change approvers in team

### DIFF
--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -52,7 +52,12 @@ class RegisterController < ApplicationController
     @change = Change.new(register_name: params[:register], payload: payload, user_id: current_user.id)
     @change.save
 
-    RegisterUpdatesMailer.register_update_notification(@change, current_user).deliver_now
+    @change_approvers = current_user.team_members.first.team.users.where.not('team_members.role' => 'basic').reject{ |u| u == current_user }
+
+    unless @change_approvers.empty?
+      RegisterUpdatesMailer.register_update_notification(@change, current_user, @change_approvers).deliver_now
+    end
+
     RegisterUpdatesMailer.register_update_receipt(@change, current_user).deliver_now
 
     flash[:notice] = 'Your update has been submitted, you\'ll recieve a confirmation email once the change is live'

--- a/app/mailers/register_updates_mailer.rb
+++ b/app/mailers/register_updates_mailer.rb
@@ -1,5 +1,5 @@
 class RegisterUpdatesMailer < GovukNotifyRails::Mailer
-  def register_update_notification(change, user)
+  def register_update_notification(change, user, change_approvers)
     set_template('cd3c0bbc-9dca-4a93-927b-55bca56943a8')
 
     set_personalisation(
@@ -9,11 +9,7 @@ class RegisterUpdatesMailer < GovukNotifyRails::Mailer
       request_date: Date.today
     )
 
-    @approvers = user.team_members.first.team.users.where.not('team_members.role' => 'basic').reject{ |u| u == user }.map(&:email)
-
-    binding.pry
-
-    mail(to: @approvers)
+    mail(to: change_approvers)
   end
 
   def register_update_receipt(change, user)


### PR DESCRIPTION
This change is needed because when a team only has a custodian and no
advanced users i.e. no-one to send the change notification to then a
server error is thrown because Notify isn’t being sent an email address.