### PR TITLE
Add UI pattern for destroying records

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -173,3 +173,33 @@ table {
     line-height: 1.25;
   }
 }
+
+.banner-dangerous {
+  @include bold-19;
+  background: $white;
+  color: $error-colour;
+  border: 5px solid $error-colour;
+  margin: 15px 0;
+  padding: 15px;
+  text-align: left;
+
+  &:focus {
+    outline: 3px solid $yellow;
+  }
+
+  .button {
+    @include button($error-colour);
+    margin-top: 10px;
+  }
+
+  a {
+    &:link,
+    &:visited {
+      color: $error-colour;
+    }
+
+    &:hover {
+      color: $mellow-red;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -174,32 +174,31 @@ table {
   }
 }
 
-.banner-dangerous {
-  @include bold-19;
-  background: $white;
-  color: $error-colour;
-  border: 5px solid $error-colour;
-  margin: 15px 0;
-  padding: 15px;
-  text-align: left;
+.destroy-confirmation {
+  @extend .error-summary;
+  margin: 0;
+  overflow: hidden;
 
   &:focus {
     outline: 3px solid $yellow;
   }
 
+  &__message {
+    color: $error-colour;
+    font-weight: 700;
+    margin-top: 0;
+  }
+
+  .button_to {
+    float: left;
+  }
+
   .button {
     @include button($error-colour);
-    margin-top: 10px;
   }
 
   a {
-    &:link,
-    &:visited {
-      color: $error-colour;
-    }
-
-    &:hover {
-      color: $mellow-red;
-    }
+    display: inline-block;
+    margin: 7px 20px;
   }
 }

--- a/app/views/layouts/_destroy.html.haml
+++ b/app/views/layouts/_destroy.html.haml
@@ -1,3 +1,4 @@
-.banner-dangerous
-  Are you sure you want to remove #{object.class}?
+.destroy-confirmation{tabindex: '-1', role: 'group'}
+  %p.destroy-confirmation__message Are you sure you want to remove #{object.class}?
   = button_to 'Yes, remove', object, method: :delete, class: 'button'
+  = link_to 'Cancel', return_path

--- a/app/views/layouts/_destroy.html.haml
+++ b/app/views/layouts/_destroy.html.haml
@@ -1,0 +1,3 @@
+.banner-dangerous
+  Are you sure you want to remove #{object.class}?
+  = button_to 'Yes, remove', object, method: :delete, class: 'button'

--- a/app/views/users/admin.html.haml
+++ b/app/views/users/admin.html.haml
@@ -8,7 +8,9 @@
       = link_to t('views.users.admin.invite'), new_user_invitation_path(role: 'admin'), class: "button align-with-heading"
 
 - if params[:delete_user]
-  = render partial: "layouts/destroy", locals: { object: User.find(params[:delete_user]) }
+  .grid-row
+    .column-two-thirds
+      = render partial: "layouts/destroy", locals: { object: User.find(params[:delete_user]), return_path: admin_path }
 
 %h3.heading-medium Team members
 .user__permissions

--- a/app/views/users/admin.html.haml
+++ b/app/views/users/admin.html.haml
@@ -7,6 +7,9 @@
     .column-one-third
       = link_to t('views.users.admin.invite'), new_user_invitation_path(role: 'admin'), class: "button align-with-heading"
 
+- if params[:delete_user]
+  = render partial: "layouts/destroy", locals: { object: User.find(params[:delete_user]) }
+
 %h3.heading-medium Team members
 .user__permissions
   %p.list-title All Admin team members can:
@@ -32,7 +35,7 @@
             = user.full_name
             %span.user__email= user.email
         %td
-          = link_to "Remove team member", user_path(user), data: { confirm: 'Are you sure?' }, method: :delete unless user == current_user
+          = link_to "Remove team member", admin_path(delete_user: user) unless user == current_user
 
 %h3.heading-medium Pending invites
 %table


### PR DESCRIPTION
This PR removes the alert confirmation dialog box and replaces with an onscreen confirmation message.

The partial is re-usable on other objects. The `link_to` method now calls the current page but passes the object id into the URL so the partial is rendered with a form(via the `button_to`) to actually delete the object.

### After
![screen shot 2017-06-27 at 10 58 05](https://user-images.githubusercontent.com/3071606/27582061-89a2efe6-5b27-11e7-878d-2967524c0f9d.png)
