### PR TITLE
Create Status at point of Change with status of pending

### DIFF
--- a/app/controllers/change_controller.rb
+++ b/app/controllers/change_controller.rb
@@ -31,13 +31,8 @@ class ChangeController < ApplicationController
   end
 
   def destroy
-    status = Status.new(
-      status: 'rejected',
-      comment: params[:comments],
-      reviewed_by_id: current_user.id
-    )
     @change = Change.find(params['id'])
-    @change.status = status
+    @change.status.update_attributes(status: 'rejected', comment: params[:comments], reviewed_by_id: current_user.id)
     @change.save
 
     RegisterUpdatesMailer.register_update_rejected(@change, current_user).deliver_now
@@ -55,8 +50,7 @@ class ChangeController < ApplicationController
       Rails.env.development? || Rails.env.staging? || response = post_to_register(@change.register_name, rsf_body)
 
       if Rails.env.development? || Rails.env.staging? || response.code == '200'
-        status = Status.new(status: 'approved', reviewed_by_id: current_user.id)
-        @change.status = status
+        @change.status.update_attributes(status: 'approved', reviewed_by_id: current_user.id)
         @change.save
 
         flash[:notice] = 'The record has been published.'

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -5,9 +5,8 @@ class RegisterController < ApplicationController
   before_action :confirm, only: [:create]
 
   def index
-    @changes = Change.where(register_name: params[:register])
-                     .joins("LEFT OUTER JOIN statuses on statuses.change_id = changes.id")
-                     .where('statuses.id is null')
+    @changes = Change.joins("LEFT OUTER JOIN statuses on statuses.change_id = changes.id")
+                     .where("register_name = '#{params[:register]}' AND statuses.status = 'pending'")
 
     @register = get_register(params[:register])._all_records
     @register[0].try(:name) ? @register = @register.sort_by(&:name) : @register = @register.sort_by(&:key)
@@ -48,6 +47,7 @@ class RegisterController < ApplicationController
     payload = generate_canonical_object(fields, params)
 
     @change = Change.new(register_name: params[:register], payload: payload, user_id: current_user.id)
+    @change.status = Status.new(status: 'pending')
     @change.save
 
     @change_approvers = Register.find_by(key: params[:register]).team.team_members.where.not(role: 'basic', user_id: current_user)

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -24,7 +24,7 @@ class RegisterController < ApplicationController
 
     if @changes.any? { |c| c.payload.value?(params[:id])}
       flash[:notice] = 'There is already a pending update on this record, this must be reviewed before creating another update'
-      redirect_to "/#{params[:register]}"
+      redirect_to registers_path
     end
 
     @form = convert_register_json(

--- a/app/views/register/index.html.haml
+++ b/app/views/register/index.html.haml
@@ -5,7 +5,7 @@
     .column-two-thirds
       %h1.heading-large #{prepare_register_name(params[:register])} register
     .column-one-third
-      = link_to "Add a new #{prepare_register_name(params[:register])}", "#{params[:register]}/new", class: "button align-with-heading"
+      = link_to "Add a new #{prepare_register_name(params[:register])}", new_register_path, class: "button align-with-heading"
 
 - if current_user.basic?
   = render partial: 'register/shared/records'

--- a/app/views/register/shared/_records.html.haml
+++ b/app/views/register/shared/_records.html.haml
@@ -19,4 +19,8 @@
         %td= register.key
         - if register.try(:name)
           %td= register.name
-        %td{style:"text-align:right"}= link_to 'Update', "#{params[:register]}/#{register.key}/edit"
+        %td{style:"text-align:right"}
+          - if @changes.any? { |c| c.payload.value?(register.key)}
+            Pending review
+          - else
+            = link_to 'Update', "#{params[:register]}/#{register.key}/edit"

--- a/app/views/register/shared/_records.html.haml
+++ b/app/views/register/shared/_records.html.haml
@@ -23,4 +23,4 @@
           - if @changes.any? { |c| c.payload.value?(register.key)}
             Pending review
           - else
-            = link_to 'Update', "#{params[:register]}/#{register.key}/edit"
+            = link_to 'Update', edit_register_path(id: register.key)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,9 +23,9 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/:register', to: 'register#index'
-  get '/:register/:id/edit', to: 'register#edit'
-  get '/:register/new', to: 'register#new'
+  get '/:register', to: 'register#index', as: 'registers'
+  get '/:register/:id/edit', to: 'register#edit', as: 'edit_register'
+  get '/:register/new', to: 'register#new', as: 'new_register'
   post '/:register', to: 'register#create'
 
 end


### PR DESCRIPTION
`status` is now created at the point of a `change` with the status of `pending`.

- Hide "Update" link
- Redirect back and show message to user

*messaging is tbc*

![screen shot 2017-09-18 at 12 34 48](https://user-images.githubusercontent.com/3071606/30540162-d50679a8-9c6d-11e7-9e6f-2ac2ea755eff.png)
