### PR TITLE
make key read only in edit view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -72,6 +72,10 @@ a[data-method='delete'] {
 .form-control.disabled {
   border-color: $grey-2;
   color: $grey-2;
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .form-label {

--- a/app/views/register/shared/_form.html.haml
+++ b/app/views/register/shared/_form.html.haml
@@ -8,7 +8,7 @@
           %span{class: 'error-message'} #{flash[field.underscore]}
       %span.form-hint #{get_description_for_register_field(field)}
       - if params[:action] == 'edit' && field == params[:register]
-        = text_field_tag field, field != params[:register] ? @form[field] : @form['key'], class: 'form-control disabled'
+        = text_field_tag field, field != params[:register] ? @form[field] : @form['key'], class: 'form-control disabled', readonly: true, tabindex: '-1'
       - else
         = text_field_tag field, @form[field], class: "form-control #{'form-control-error' if has_error}"
   = f.submit 'Continue', class: 'button'


### PR DESCRIPTION
When you are editing an existing record you should not be able to update the key.
![screen shot 2017-09-28 at 15 12 17](https://user-images.githubusercontent.com/1764158/30971343-8902bafe-a45f-11e7-8fb2-2e7983f04806.png)
