### PR TITLE
tweak error wording to be closer to UCD style

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -2,7 +2,7 @@ module DeviseHelper
   def devise_error_messages!
     return "" if resource.errors.empty?
 
-    messages = resource.errors.map { |k, v| content_tag(:li, link_to("#{k.to_s.humanize} #{v}", "##{resource.class.model_name.to_s.downcase}_#{k}")) }.join
+    messages = resource.errors.map { |k, v| content_tag(:li, link_to("Your #{k.to_s.humanize} #{v}", "##{resource.class.model_name.to_s.downcase}_#{k}")) }.join
     headline = "Please correct the #{'error'.pluralize(resource.errors.count)} below"
 
     html = <<-HTML

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,11 @@
 ---
 en:
   errors:
+    format: "Your %{attribute} %{message}"
     messages:
       blank: is required
       confirmation: must match your new password
+      invalid: is incorrect
   views:
     users:
       admin:


### PR DESCRIPTION
Tweak error message format  to be closer to that requested by UCD CC @gtdata
![screen shot 2017-10-11 at 16 44 49](https://user-images.githubusercontent.com/1764158/31451293-a24f1e6e-aea3-11e7-848d-20385a611268.png)
