### PR TITLE
Key Uniqueness Validator refactor

### DIFF
--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -13,7 +13,6 @@ module ValidationHelper
         include ActiveModel::Validations
 
         # Custom validators are defined in app/validators
-        validates_with KeyUniquenessValidator, records: records, register_name: register_name, is_create: params[:is_create]
         field_definitions.each do |field|
           field_sym = field_to_sym.call(field[:item]['field'])
           attr_accessor field_sym
@@ -24,7 +23,7 @@ module ValidationHelper
           when 'curie'
             validates field_sym, linked: { register_linked: field[:item]['register'] }, allow_blank: true
           when 'string'
-            validates field_sym, presence: { message: 'Field %{attribute} is required' }, allow_blank: !is_key
+            validates field_sym, presence: { message: 'Field %{attribute} is required' }, allow_blank: !is_key, key_uniqueness: { records: records, is_create: params[:is_create] }, if: -> { is_key == true }
           when 'url'
             validates field_sym, url: true, allow_blank: true
           when 'datetime'

--- a/app/validators/key_uniqueness_validator.rb
+++ b/app/validators/key_uniqueness_validator.rb
@@ -1,13 +1,11 @@
-class KeyUniquenessValidator < ActiveModel::Validator
-  def validate(record)
-    key = options[:register_name]
+class KeyUniquenessValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
     records = options[:records]
     is_create = options[:is_create]
+    key = attribute.to_s.dasherize
     if ActiveModel::Type::Boolean.new.cast(is_create)
-      register_sym = key.underscore.to_sym
-      key_param = record.instance_variable_get("@#{key.underscore}")
-      if records.select {|r| r[:item][key] == key_param}.present?
-        record.errors.add register_sym, 'This code is already in use for another record, please use another code'
+      if records.select { |r| r[:item][key] == value }.present?
+        record.errors.add attribute, 'This code is already in use for another record, please use another code'
       end
     end
   end

--- a/spec/helpers/validation_helper_spec.rb
+++ b/spec/helpers/validation_helper_spec.rb
@@ -4,6 +4,7 @@ require 'yaml'
 
 RSpec.describe ValidationHelper do
   field_definitions = YAML.load_file('./spec/support/field_definitions.yaml')
+  records = YAML.load_file('./spec/support/records.yml')
   data_validator = ValidationHelper::DataValidator.new
 
   describe 'get_form_errors' do
@@ -31,6 +32,11 @@ RSpec.describe ValidationHelper do
     it 'returns an error if key is not populated' do
       params = { country: '', register: 'country' }
       expect(data_validator.get_form_errors(params, field_definitions, 'country', nil).messages).to eql(country: ['Field Country is required'])
+    end
+
+    it 'returns an error if key already exists when performing a create' do
+      params = { 'country' => 'SU', 'is_create': 'true' }
+      expect(data_validator.get_form_errors(params, field_definitions, 'country', records).messages).to eql(country: ['This code is already in use for another record, please use another code'])
     end
 
     it 'returns no errors if curie is valid' do

--- a/spec/support/records.yml
+++ b/spec/support/records.yml
@@ -1,0 +1,1848 @@
+---
+- :key: !ruby/string:RestClient::Response SU
+  :entry_number: 1
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e94c4a9ab00d951dadde848ee2c9fe51628b22ff2e0a88bff4cca6e4e6086d7a
+  :item:
+    citizen-names: Soviet citizen
+    country: SU
+    end-date: '1991-12-25'
+    name: USSR
+    official-name: Union of Soviet Socialist Republics
+- :key: !ruby/string:RestClient::Response DE
+  :entry_number: 71
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:747dbb718cb9f9799852e7bf698c499e6b83fb1a46ec06dbd6087f35c1e955cc
+  :item:
+    citizen-names: German
+    country: DE
+    name: Germany
+    official-name: The Federal Republic of Germany
+    start-date: '1990-10-03'
+- :key: !ruby/string:RestClient::Response DD
+  :entry_number: 3
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e1357671d0da24668952373d0cdf9f7659a1b155e45c8fb3c2f24331e46edc26
+  :item:
+    citizen-names: East German
+    country: DD
+    end-date: '1990-10-02'
+    name: East Germany
+    official-name: Germany Democratic Republic
+- :key: !ruby/string:RestClient::Response YU
+  :entry_number: 4
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a074752a77011b18447401652029a9129c53b4ee35e1d99e6dec8b42ff4a0103
+  :item:
+    citizen-names: Yugoslavian
+    country: YU
+    end-date: '1992-04-28'
+    name: Yugoslavia
+    official-name: Socialist Federal Republic of Yugoslavia
+- :key: !ruby/string:RestClient::Response CS
+  :entry_number: 5
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:0031f311f87260b07f4c7b25748cfdd8c2d2efa3c15fc98c33dd8563fafb6476
+  :item:
+    citizen-names: Czechoslovak
+    country: CS
+    end-date: '1992-12-31'
+    name: Czechoslovakia
+    official-name: Czechoslovak Republic
+- :key: !ruby/string:RestClient::Response GB
+  :entry_number: 6
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb
+  :item:
+    citizen-names: Briton;British citizen
+    country: GB
+    name: United Kingdom
+    official-name: The United Kingdom of Great Britain and Northern Ireland
+- :key: !ruby/string:RestClient::Response AF
+  :entry_number: 7
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6bf7f01f268fa6d18e53eb7d5ebadb41c25c4aa2eedecfb7bc863e233ec99e24
+  :item:
+    citizen-names: Afghan
+    country: AF
+    name: Afghanistan
+    official-name: The Islamic Republic of Afghanistan
+- :key: !ruby/string:RestClient::Response AL
+  :entry_number: 8
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:9d04a7e04ac92ab809a7471e7142617bc30a4b2d2f30c1002520a4a1d216f2a5
+  :item:
+    citizen-names: Albanian
+    country: AL
+    name: Albania
+    official-name: The Republic of Albania
+- :key: !ruby/string:RestClient::Response DZ
+  :entry_number: 9
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:3548cdf528e450626113d44cdd4ac3a19ff992313fe814899c3198d4e0baeff9
+  :item:
+    citizen-names: Algerian
+    country: DZ
+    name: Algeria
+    official-name: The People's Democratic Republic of Algeria
+- :key: !ruby/string:RestClient::Response AD
+  :entry_number: 10
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:14fcb5099f0eff4c40d5a85b0e3c2f1a04337dc69dace1fc5c64ec9758a19b13
+  :item:
+    citizen-names: Andorran
+    country: AD
+    name: Andorra
+    official-name: The Principality of Andorra
+- :key: !ruby/string:RestClient::Response AO
+  :entry_number: 11
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c66f7a4f655d41425d2aba07bc6204c1d764c3fd8cfba9b3f8ed25baae244427
+  :item:
+    citizen-names: Angolan
+    country: AO
+    name: Angola
+    official-name: The Republic of Angola
+    start-date: '1975-11-11'
+- :key: !ruby/string:RestClient::Response AG
+  :entry_number: 12
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d97b6f4b277e0af0d61456c75106a38cecace2f362d1bfa29e704a63c84e4328
+  :item:
+    citizen-names: Citizen of Antigua and Barbuda
+    country: AG
+    name: Antigua and Barbuda
+    official-name: Antigua and Barbuda
+    start-date: '1981-11-01'
+- :key: !ruby/string:RestClient::Response AR
+  :entry_number: 13
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ca880f33b29256578d0be532579837f08a7bdaf1b968adf6e63708ec2d782a53
+  :item:
+    citizen-names: Argentine;Argentinian
+    country: AR
+    name: Argentina
+    official-name: The Argentine Republic
+- :key: !ruby/string:RestClient::Response AM
+  :entry_number: 14
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:47b2db84d1a0e3abc6bca332a3c40253f84225f181b37a312b0d3c14b32727d1
+  :item:
+    citizen-names: Armenian
+    country: AM
+    name: Armenia
+    official-name: The Republic of Armenia
+    start-date: '1991-09-21'
+- :key: !ruby/string:RestClient::Response AU
+  :entry_number: 15
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a5917aaa595c7dcbade7138d92fc249848df6a9c2efc282e28fb540b3dc3d0bb
+  :item:
+    citizen-names: Australian
+    country: AU
+    name: Australia
+    official-name: The Commonwealth of Australia
+- :key: !ruby/string:RestClient::Response AT
+  :entry_number: 16
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:77e8694806852b806d9be797cbcb068ca4a2d7c9ed499daf8341d614686de624
+  :item:
+    citizen-names: Austrian
+    country: AT
+    name: Austria
+    official-name: The Republic of Austria
+- :key: !ruby/string:RestClient::Response AZ
+  :entry_number: 17
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:be1bdd0de400a14cbd3142ab1c5ce4e06bb4deddeb13bffd4890058f04de651f
+  :item:
+    citizen-names: Azerbaijani
+    country: AZ
+    name: Azerbaijan
+    official-name: The Republic of Azerbaijan
+    start-date: '1991-08-30'
+- :key: !ruby/string:RestClient::Response BS
+  :entry_number: 203
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a77f1e11270aab0c5bf315b2e7c268a7aff89713578020e1b4183c6df2b2c0e7
+  :item:
+    citizen-names: Bahamian
+    country: BS
+    name: The Bahamas
+    official-name: The Commonwealth of The Bahamas
+- :key: !ruby/string:RestClient::Response BH
+  :entry_number: 19
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:dd4dd8658072865671172333a641e6d37e1d477baa3bf23e7a6b52328a6162c1
+  :item:
+    citizen-names: Bahraini
+    country: BH
+    name: Bahrain
+    official-name: The Kingdom of Bahrain
+- :key: !ruby/string:RestClient::Response BD
+  :entry_number: 20
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:abad68e29c01ae14b24e828fa5b99bad6565800cd9591bf5cf32679013e726a8
+  :item:
+    citizen-names: Bangladeshi
+    country: BD
+    name: Bangladesh
+    official-name: The People's Republic of Bangladesh
+- :key: !ruby/string:RestClient::Response BB
+  :entry_number: 21
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:15203db1a0b4ea2685cda93fb8ca9a1adcdd41a63f8eef03365eba5332a2c3e3
+  :item:
+    citizen-names: Barbadian
+    country: BB
+    name: Barbados
+    official-name: Barbados
+- :key: !ruby/string:RestClient::Response BY
+  :entry_number: 22
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:4a84d2e46ab352b337f84e92dc593332fc6bfa994de698acb37adfd0113813c0
+  :item:
+    citizen-names: Belarusian
+    country: BY
+    name: Belarus
+    official-name: The Republic of Belarus
+    start-date: '1991-08-25'
+- :key: !ruby/string:RestClient::Response BE
+  :entry_number: 23
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:1924e51549dbc45de01cfb444b1ace3f20893fff184bdc9426eb0fdec1192bf6
+  :item:
+    citizen-names: Belgian
+    country: BE
+    name: Belgium
+    official-name: The Kingdom of Belgium
+- :key: !ruby/string:RestClient::Response BZ
+  :entry_number: 24
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c63e4432bd5967cc660b740ef0e371372f1734db62f464b46a05070b9e97559b
+  :item:
+    citizen-names: Citizen of Belize
+    country: BZ
+    name: Belize
+    official-name: Belize
+    start-date: '1981-09-21'
+- :key: !ruby/string:RestClient::Response BJ
+  :entry_number: 25
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:1fa352d281dc7cce463a125454d841e5b6cd5bf0a3f57b4d59c6e48298e105fc
+  :item:
+    citizen-names: Beninese
+    country: BJ
+    name: Benin
+    official-name: The Republic of Benin
+- :key: !ruby/string:RestClient::Response BT
+  :entry_number: 26
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:51e5fef041cffbcb6cc6bbcaf292ada263d09b1c4e533cf96da8b1c0d24b1500
+  :item:
+    citizen-names: Bhutanese
+    country: BT
+    name: Bhutan
+    official-name: The Kingdom of Bhutan
+- :key: !ruby/string:RestClient::Response BO
+  :entry_number: 27
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:058d5947158d724aac39bd3e069be83fb21856deb4e00ef1734c080169ff916d
+  :item:
+    citizen-names: Bolivian
+    country: BO
+    name: Bolivia
+    official-name: The Plurinational State of Bolivia
+- :key: !ruby/string:RestClient::Response BA
+  :entry_number: 28
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:fa02a4104dd3181cae2ef62397268f1d95d37150a15009ba61b54f84d61fb4b0
+  :item:
+    citizen-names: Citizen of Bosnia and Herzegovina
+    country: BA
+    name: Bosnia and Herzegovina
+    official-name: Bosnia and Herzegovina
+    start-date: '1992-03-03'
+- :key: !ruby/string:RestClient::Response BW
+  :entry_number: 29
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:608cd602c89522050e8235d2b145ddd1d1817c6c442bb6fec095ef292b8997d1
+  :item:
+    citizen-names: Citizen of Botswana
+    country: BW
+    name: Botswana
+    official-name: The Republic of Botswana
+- :key: !ruby/string:RestClient::Response BR
+  :entry_number: 30
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:5ad9666bf6362ff05bcff93c49138fa1010f9093139ad916deabc665e3c5001f
+  :item:
+    citizen-names: Brazilian
+    country: BR
+    name: Brazil
+    official-name: The Federative Republic of Brazil
+- :key: !ruby/string:RestClient::Response BN
+  :entry_number: 31
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:86f3445909c019ec4635ea638a6c949c354dd027855f4929da775727c46cbf72
+  :item:
+    citizen-names: Citizen of Brunei
+    country: BN
+    name: Brunei
+    official-name: Brunei Darussalam
+    start-date: '1984-01-01'
+- :key: !ruby/string:RestClient::Response BG
+  :entry_number: 32
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:56f710e5a8d7eb6fffbeb819cfa901ae9af121b2f64bd6b91534bb7d09954e9f
+  :item:
+    citizen-names: Bulgarian
+    country: BG
+    name: Bulgaria
+    official-name: The Republic of Bulgaria
+- :key: !ruby/string:RestClient::Response BF
+  :entry_number: 33
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:91af7bcc47b161b8948f743c265479234dfae4924f3211a72bcbde4250832bd9
+  :item:
+    citizen-names: Burkinabe;Burkinan
+    country: BF
+    name: Burkina Faso
+    official-name: Burkina Faso
+- :key: !ruby/string:RestClient::Response MM
+  :entry_number: 34
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d826a3c8c191b08c3da4c7b61e9e8fc1dcb2d6501211df4814d9075f6b865164
+  :item:
+    citizen-names: Burmese
+    country: MM
+    name: Burma
+    official-name: The Republic of the Union of Myanmar
+- :key: !ruby/string:RestClient::Response BI
+  :entry_number: 35
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:50f7e2bf23b157a5d89ff0139fa453bd98bcfd2331dd98806ce52ef6d33b5a5c
+  :item:
+    citizen-names: Citizen of Burundi
+    country: BI
+    name: Burundi
+    official-name: The Republic of Burundi
+- :key: !ruby/string:RestClient::Response KH
+  :entry_number: 36
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ce4f468616501c8067649db804e60cb2f177f5d1ab72b371fcd3d8498df7adcb
+  :item:
+    citizen-names: Cambodian
+    country: KH
+    name: Cambodia
+    official-name: The Kingdom of Cambodia
+- :key: !ruby/string:RestClient::Response CM
+  :entry_number: 37
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:2de017cea16f6444dcf5e63459385db222c9211a0353ee62da56d1771339842f
+  :item:
+    citizen-names: Cameroonian
+    country: CM
+    name: Cameroon
+    official-name: The Republic of Cameroon
+- :key: !ruby/string:RestClient::Response CA
+  :entry_number: 38
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:27c8a0f5af23762e30b11ce5f743abfb443a5c74e5d7c9050e32411a96e6b905
+  :item:
+    citizen-names: Canadian
+    country: CA
+    name: Canada
+    official-name: Canada
+- :key: !ruby/string:RestClient::Response CV
+  :entry_number: 39
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:afe914d82eafd2a8c92d51be7b9900b6602caf51941cdfd0c4b5197f9682a4f5
+  :item:
+    citizen-names: Cape Verdean
+    country: CV
+    name: Cape Verde
+    official-name: The Republic of Cabo Verde
+    start-date: '1975-07-05'
+- :key: !ruby/string:RestClient::Response CF
+  :entry_number: 40
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:17d940731b9abb32f195f1c8d4e2fb2172777fa1ae3074f8f7277c3982036f63
+  :item:
+    citizen-names: Citizen of the Central African Republic
+    country: CF
+    name: Central African Republic
+    official-name: The Central African Republic
+- :key: !ruby/string:RestClient::Response TD
+  :entry_number: 41
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d9289603bc37049b30cc8b169a59780d93ac9bf4b838d5c4bf3ffb6d4b14354e
+  :item:
+    citizen-names: Chadian
+    country: TD
+    name: Chad
+    official-name: The Republic of Chad
+- :key: !ruby/string:RestClient::Response CL
+  :entry_number: 42
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:20876a6e92af5c05fe7a11ee0111b1cf04ff5c158abe1f7334755a766a71c180
+  :item:
+    citizen-names: Chilean
+    country: CL
+    name: Chile
+    official-name: The Republic of Chile
+- :key: !ruby/string:RestClient::Response CN
+  :entry_number: 43
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:bc808ed6f3eb9aba16a4624de0f3e03404d3c35421382bf529dd9a503f341856
+  :item:
+    citizen-names: Chinese
+    country: CN
+    name: China
+    official-name: The People's Republic of China
+- :key: !ruby/string:RestClient::Response CO
+  :entry_number: 44
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c8b0ab444b62407caf3d5ae2eb99eb42e25cb9b4487c978dbdb49edb939e45c5
+  :item:
+    citizen-names: Colombian
+    country: CO
+    name: Colombia
+    official-name: The Republic of Colombia
+- :key: !ruby/string:RestClient::Response KM
+  :entry_number: 45
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:7d7c106548431f31218df1535a93a35ea3b3f22d2bf9318d674c927ccef8fe9a
+  :item:
+    citizen-names: Comoran
+    country: KM
+    name: Comoros
+    official-name: The Union of the Comoros
+    start-date: '1975-07-06'
+- :key: !ruby/string:RestClient::Response CG
+  :entry_number: 46
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:9122cdf8b3e283e6d3d2240558ef6ef2e57cb8617b4624e3bcb6b9ca65e2886f
+  :item:
+    citizen-names: Citizen of the Republic of the Congo
+    country: CG
+    name: Congo
+    official-name: The Republic of the Congo
+- :key: !ruby/string:RestClient::Response CD
+  :entry_number: 47
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:dea4971f37c8b1d20556b05824cf39e60389c9778cabe6a81ff5af762596427d
+  :item:
+    citizen-names: Citizen of The Democratic Republic of the Congo
+    country: CD
+    name: Congo (Democratic Republic)
+    official-name: The Democratic Republic of the Congo
+- :key: !ruby/string:RestClient::Response CR
+  :entry_number: 48
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:9f1322807b4dad6d120eeacacd812b90b9ab3f41feab39be45fcc1725d2c94b9
+  :item:
+    citizen-names: Costa Rican
+    country: CR
+    name: Costa Rica
+    official-name: The Republic of Costa Rica
+- :key: !ruby/string:RestClient::Response HR
+  :entry_number: 49
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:208e2540acd0d6209a6ab88e9b554cfbed2a226580f0d4d452a13389f79fc9f7
+  :item:
+    citizen-names: Croatian
+    country: HR
+    name: Croatia
+    official-name: The Republic of Croatia
+    start-date: '1991-06-25'
+- :key: !ruby/string:RestClient::Response CU
+  :entry_number: 50
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:0e05f13f484f53fbafc58b7d935a8640ebecbac26b1962dcd7ef05f8d8fc995a
+  :item:
+    citizen-names: Cuban
+    country: CU
+    name: Cuba
+    official-name: The Republic of Cuba
+- :key: !ruby/string:RestClient::Response CY
+  :entry_number: 51
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c0b0738976093ce8711163068796c29deec46412c056ec948697be35bd1c30f1
+  :item:
+    citizen-names: Cypriot
+    country: CY
+    name: Cyprus
+    official-name: The Republic of Cyprus
+- :key: !ruby/string:RestClient::Response CZ
+  :entry_number: 205
+  :timestamp: !ruby/string:RestClient::Response '2016-11-11T16:25:07Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720
+  :item:
+    citizen-names: Czech
+    country: CZ
+    name: Czechia
+    official-name: The Czech Republic
+    start-date: '1993-01-01'
+- :key: !ruby/string:RestClient::Response DK
+  :entry_number: 53
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e1b54fbe5885d14069c125cb39ee489389e3028fd69b9b0e419f2ec688aad882
+  :item:
+    citizen-names: Dane
+    country: DK
+    name: Denmark
+    official-name: The Kingdom of Denmark
+- :key: !ruby/string:RestClient::Response DJ
+  :entry_number: 54
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:fbf149fca3315b50710077b017cdf3b569cc41f2a75e787b9dfb4ac48e0f31cf
+  :item:
+    citizen-names: Djiboutian
+    country: DJ
+    name: Djibouti
+    official-name: The Republic of Djibouti
+    start-date: '1977-06-27'
+- :key: !ruby/string:RestClient::Response DM
+  :entry_number: 55
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ca92ee5217741a2ca6051d25367975dd934854f81dfa6e28dc91f6ec1bfabab4
+  :item:
+    citizen-names: Dominican
+    country: DM
+    name: Dominica
+    official-name: The Commonwealth of Dominica
+    start-date: '1978-11-03'
+- :key: !ruby/string:RestClient::Response DO
+  :entry_number: 56
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a40b482e8e2966406769b5fdd5389da40454209c9d6a7dfcd18ecbea154f3412
+  :item:
+    citizen-names: Citizen of the Dominican Republic
+    country: DO
+    name: Dominican Republic
+    official-name: The Dominican Republic
+- :key: !ruby/string:RestClient::Response TL
+  :entry_number: 57
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:faba1d16a599882f6c50f588bd87321e3629c2a87d974579efb65fb84355eed0
+  :item:
+    citizen-names: East Timorese
+    country: TL
+    name: East Timor
+    official-name: The Democratic Republic of Timor-Leste
+- :key: !ruby/string:RestClient::Response EC
+  :entry_number: 58
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:80442f4556dbf969424a566ecacf075dc09e5c8a3807d252a12c89f4dbb4769b
+  :item:
+    citizen-names: Ecuadorean
+    country: EC
+    name: Ecuador
+    official-name: The Republic of Ecuador
+- :key: !ruby/string:RestClient::Response EG
+  :entry_number: 59
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:be5f4584e3ee1422646a1bd179fc8ea7936a728f0a88d3becc52b83d3fa5c209
+  :item:
+    citizen-names: Egyptian
+    country: EG
+    name: Egypt
+    official-name: The Arab Republic of Egypt
+- :key: !ruby/string:RestClient::Response SV
+  :entry_number: 60
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e1e6dd1783266b91deaee0adf59b32945466e5b57eb1abe18bbab91c35f562f0
+  :item:
+    citizen-names: Salvadorean
+    country: SV
+    name: El Salvador
+    official-name: The Republic of El Salvador
+- :key: !ruby/string:RestClient::Response GQ
+  :entry_number: 61
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d8f801a489b33a26c7457f9ad9eb49f6a3973f6be2fbfe3bbb6b13e3c7a0b813
+  :item:
+    citizen-names: Equatorial Guinean
+    country: GQ
+    name: Equatorial Guinea
+    official-name: The Republic of Equatorial Guinea
+- :key: !ruby/string:RestClient::Response ER
+  :entry_number: 62
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:0d62a0cca252b73a826e1db642cdde4a89adf8747c3ecf79e5a34cd1bb94792a
+  :item:
+    citizen-names: Eritrean
+    country: ER
+    name: Eritrea
+    official-name: The State of Eritrea
+    start-date: '1993-05-24'
+- :key: !ruby/string:RestClient::Response EE
+  :entry_number: 63
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:73c5327e464414b8a6a87cbe3f736c7a001452abe87bb6d3ec8d4f221a4d25c6
+  :item:
+    citizen-names: Estonian
+    country: EE
+    name: Estonia
+    official-name: The Republic of Estonia
+    start-date: '1991-08-20'
+- :key: !ruby/string:RestClient::Response ET
+  :entry_number: 64
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a1940769be9793c6904cd01dc9297f61aa3f49b99007bff734c30269e90b7046
+  :item:
+    citizen-names: Ethiopian
+    country: ET
+    name: Ethiopia
+    official-name: The Federal Democratic Republic of Ethiopia
+- :key: !ruby/string:RestClient::Response FJ
+  :entry_number: 65
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:dfd316190c8a79880bde587da94d3f0b8eeeb752626a0a64697f2288f1ee4e1f
+  :item:
+    citizen-names: Citizen of Fiji
+    country: FJ
+    name: Fiji
+    official-name: The Republic of Fiji
+- :key: !ruby/string:RestClient::Response FI
+  :entry_number: 66
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:df2c57df1a3fce1cdd2b55918e74dcd2cc7e11eec07a619b07fc0a90269450ee
+  :item:
+    citizen-names: Finn
+    country: FI
+    name: Finland
+    official-name: The Republic of Finland
+- :key: !ruby/string:RestClient::Response FR
+  :entry_number: 67
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e583abf7519bb6c92bbdf9ca90d2891add60a4b34b665ed83a86650a98b54c1c
+  :item:
+    citizen-names: French citizen;Frenchman;Frenchwoman
+    country: FR
+    name: France
+    official-name: The French Republic
+- :key: !ruby/string:RestClient::Response GA
+  :entry_number: 68
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:1f133cb20145534e818734028da0d9fcd823f1ee199b2ffeb7f277c0db25e2a0
+  :item:
+    citizen-names: Gabonese
+    country: GA
+    name: Gabon
+    official-name: The Gabonese Republic
+- :key: !ruby/string:RestClient::Response GM
+  :entry_number: 206
+  :timestamp: !ruby/string:RestClient::Response '2017-03-29T14:22:30Z'
+  :hash: !ruby/string:RestClient::Response sha-256:0429375c4fb403288ef816e5dd38a24f192e35b8f55e40cc6266eb25eaef77b1
+  :item:
+    citizen-names: Gambian
+    country: GM
+    name: The Gambia
+    official-name: The Republic of The Gambia
+- :key: !ruby/string:RestClient::Response GE
+  :entry_number: 70
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e057a6d45ba312f55cdd31d8fcad5a79f344d0d8833a34c416a5859f67c30e5c
+  :item:
+    citizen-names: Georgian
+    country: GE
+    name: Georgia
+    official-name: Georgia
+    start-date: '1991-04-09'
+- :key: !ruby/string:RestClient::Response GH
+  :entry_number: 72
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:dc1d12943ea264de937468b254286e5ebd8acd316e21bf667076ebdb8c111bd1
+  :item:
+    citizen-names: Ghanaian
+    country: GH
+    name: Ghana
+    official-name: The Republic of Ghana
+- :key: !ruby/string:RestClient::Response GR
+  :entry_number: 73
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:85bf72046e8b6935b2aee45ef4a13a170bb819956c10de92277611dfd196e202
+  :item:
+    citizen-names: Greek
+    country: GR
+    name: Greece
+    official-name: The Hellenic Republic
+- :key: !ruby/string:RestClient::Response GD
+  :entry_number: 74
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:23ee932e81d9be1b7bc52be0644f810a5c526591df791d64e3b1464bc2404729
+  :item:
+    citizen-names: Grenadian
+    country: GD
+    name: Grenada
+    official-name: Grenada
+    start-date: '1974-02-07'
+- :key: !ruby/string:RestClient::Response GT
+  :entry_number: 75
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6b9bbb2d3409c1f2751ae36c22e84c1e954fdc2a1b2cb6ecf2635260048a3167
+  :item:
+    citizen-names: Guatemalan
+    country: GT
+    name: Guatemala
+    official-name: The Republic of Guatemala
+- :key: !ruby/string:RestClient::Response GN
+  :entry_number: 76
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:21eccd06c2c2d23e3f3cfdd3be61ab6cfa08b15d4a0a7188ea4bb25c28935869
+  :item:
+    citizen-names: Guinean
+    country: GN
+    name: Guinea
+    official-name: The Republic of Guinea
+- :key: !ruby/string:RestClient::Response GW
+  :entry_number: 77
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d0e833cb483fe5bcbbd2484794326fd201b2dc83c9b48c3496aff56478abf57c
+  :item:
+    citizen-names: Citizen of Guinea-Bissau
+    country: GW
+    name: Guinea-Bissau
+    official-name: The Republic of Guinea-Bissau
+- :key: !ruby/string:RestClient::Response GY
+  :entry_number: 78
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:36ee7af0d204735abf3d6bebbf2e80fb930bd5db34f4c9471d1f3c231e133157
+  :item:
+    citizen-names: Guyanese
+    country: GY
+    name: Guyana
+    official-name: The Co-operative Republic of Guyana
+- :key: !ruby/string:RestClient::Response HT
+  :entry_number: 79
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:f9e92c07726ac713f603f9c8ccd97750977c82b57f970f4fe42cc42d8f35df6a
+  :item:
+    citizen-names: Haitian
+    country: HT
+    name: Haiti
+    official-name: The Republic of Haiti
+- :key: !ruby/string:RestClient::Response HN
+  :entry_number: 80
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:1b1c87ceaa3a398aad831d17747ba9ad6c6dbe2146f4b3c15d48af8a8ae45946
+  :item:
+    citizen-names: Honduran
+    country: HN
+    name: Honduras
+    official-name: The Republic of Honduras
+- :key: !ruby/string:RestClient::Response HU
+  :entry_number: 81
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c413c7c33f93db2ced0a16a23ee7ace9525b74d5e2f3f31ef38b820c6e4a33c1
+  :item:
+    citizen-names: Hungarian
+    country: HU
+    name: Hungary
+    official-name: Hungary
+- :key: !ruby/string:RestClient::Response IS
+  :entry_number: 82
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:8600cf69794d9854f8dcd7e51fbcdf8f31678fba12f1c8185fb61211be0628e9
+  :item:
+    citizen-names: Icelander
+    country: IS
+    name: Iceland
+    official-name: The Republic of Iceland
+- :key: !ruby/string:RestClient::Response IN
+  :entry_number: 83
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ee78f485f8ad1a169745366da4057c8fc0102e9461b5c1f0d12e1e381387217e
+  :item:
+    citizen-names: Indian
+    country: IN
+    name: India
+    official-name: The Republic of India
+- :key: !ruby/string:RestClient::Response ID
+  :entry_number: 84
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:9879968660823c6f5566ca91cac4f161b2e94e8f9497958ddd044d66abb844af
+  :item:
+    citizen-names: Indonesian
+    country: ID
+    name: Indonesia
+    official-name: The Republic of Indonesia
+- :key: !ruby/string:RestClient::Response IR
+  :entry_number: 85
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ecd8f9738381675d76ed85a3df8afa7e07f7fdcaba372890aa4aa159cd6ceca2
+  :item:
+    citizen-names: Iranian
+    country: IR
+    name: Iran
+    official-name: The Islamic Republic of Iran
+- :key: !ruby/string:RestClient::Response IQ
+  :entry_number: 86
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:4a92f2fe43dcb63ab3b66e3f4f9ce328bbc61f020ee0ecece4e3da40172cabe0
+  :item:
+    citizen-names: Iraqi
+    country: IQ
+    name: Iraq
+    official-name: The Republic of Iraq
+- :key: !ruby/string:RestClient::Response IE
+  :entry_number: 87
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:aecb4ee6a7a4e49d1f968f02a11550dc8117382b2064dff7c0454c66d44e86f6
+  :item:
+    citizen-names: Citizen of Ireland;Irish citizen
+    country: IE
+    name: Ireland
+    official-name: Ireland
+- :key: !ruby/string:RestClient::Response IL
+  :entry_number: 88
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:03fd1378efb674662cc302e068078de72e6fd74489ffba19d8f474b6e6c1bd3c
+  :item:
+    citizen-names: Israeli
+    country: IL
+    name: Israel
+    official-name: The State of Israel
+- :key: !ruby/string:RestClient::Response IT
+  :entry_number: 89
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:fb70bc281d1b2a73880c2e0d86f8253db0a1397ddca6258e9253921264ca34bc
+  :item:
+    citizen-names: Italian
+    country: IT
+    name: Italy
+    official-name: The Italian Republic
+- :key: !ruby/string:RestClient::Response CI
+  :entry_number: 90
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:7c16257bd45b4716914010b39dd40e5a6b985b8928d7b8bb0fe3005d2f2b0fec
+  :item:
+    citizen-names: Citizen of the Ivory Coast
+    country: CI
+    name: Ivory Coast
+    official-name: The Republic of Cote D'Ivoire
+- :key: !ruby/string:RestClient::Response JM
+  :entry_number: 91
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:13e5cb274e904817afada4563a56509461535c8aff15502a0b7efad226357fc5
+  :item:
+    citizen-names: Jamaican
+    country: JM
+    name: Jamaica
+    official-name: Jamaica
+- :key: !ruby/string:RestClient::Response JP
+  :entry_number: 92
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:3a38ed71e5de0c0ff8c973f22b3965308b6567096d0952c476f1a1484e4bf62a
+  :item:
+    citizen-names: Japanese
+    country: JP
+    name: Japan
+    official-name: Japan
+- :key: !ruby/string:RestClient::Response JO
+  :entry_number: 93
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6bff7775498dfa882f1911170fe467f8f64619dd1cab41e1b31947719a762574
+  :item:
+    citizen-names: Jordanian
+    country: JO
+    name: Jordan
+    official-name: The Hashemite Kingdom of Jordan
+- :key: !ruby/string:RestClient::Response KZ
+  :entry_number: 94
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:5cdae4a0d6da81a7615d20f1ece6a6bc8ab50bfe7b010b08bd484c7470945d45
+  :item:
+    citizen-names: Kazakh
+    country: KZ
+    name: Kazakhstan
+    official-name: The Republic of Kazakhstan
+    start-date: '1991-12-16'
+- :key: !ruby/string:RestClient::Response KE
+  :entry_number: 95
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a47f121bcb7e4c7279e8d566ef62ef21802962f68fc87cdde9cb3e054d96ca6f
+  :item:
+    citizen-names: Kenyan
+    country: KE
+    name: Kenya
+    official-name: The Republic of Kenya
+- :key: !ruby/string:RestClient::Response KI
+  :entry_number: 96
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:69eeacbe31eb280ee93fee5b3e701a58f3f31c3180d887932b7fdb07e6b8f319
+  :item:
+    citizen-names: Citizen of Kiribati
+    country: KI
+    name: Kiribati
+    official-name: The Republic of Kiribati
+    start-date: '1979-07-12'
+- :key: !ruby/string:RestClient::Response KP
+  :entry_number: 97
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:417078064cda8a732469ca7c3908e4a3bb8be7e5b262b7304c7aa050661164c0
+  :item:
+    citizen-names: Citizen of the Democratic People's Republic of Korea;Citizen of
+      the DPRK
+    country: KP
+    name: North Korea
+    official-name: The Democratic People's Republic of Korea
+- :key: !ruby/string:RestClient::Response KR
+  :entry_number: 98
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:cfcb269265bf8cae36bca46d6681f7134b168b2aeceef4131809594b0e6ecde8
+  :item:
+    citizen-names: South Korean
+    country: KR
+    name: South Korea
+    official-name: The Republic of Korea
+- :key: !ruby/string:RestClient::Response XK
+  :entry_number: 99
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:fb6dbf64942d56e0f9706693334fabb8fd4cfacaf796ee01522146e0d608ff54
+  :item:
+    citizen-names: Kosovan
+    country: XK
+    name: Kosovo
+    official-name: The Republic of Kosovo
+- :key: !ruby/string:RestClient::Response KW
+  :entry_number: 100
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:eb3ee00e6149cd734a7fa7e1f01a5fbf5fb50e1b38a065fd97d6ad3017750351
+  :item:
+    citizen-names: Kuwaiti
+    country: KW
+    name: Kuwait
+    official-name: The State of Kuwait
+- :key: !ruby/string:RestClient::Response KG
+  :entry_number: 101
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:8b748c574bf975990e47e69df040b47126d2a0a3895b31dce73988fba2ba27d8
+  :item:
+    citizen-names: Kyrgyz
+    country: KG
+    name: Kyrgyzstan
+    official-name: The Kyrgyz Republic
+    start-date: '1991-08-31'
+- :key: !ruby/string:RestClient::Response LA
+  :entry_number: 102
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:490636974f8087e4518d222eba08851dd3e2b85095f2b1427ff6ecd3fa482435
+  :item:
+    citizen-names: Lao
+    country: LA
+    name: Laos
+    official-name: The Lao People's Democratic Republic
+- :key: !ruby/string:RestClient::Response LV
+  :entry_number: 103
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c1de7c598cc2b326018a66b006ad5db9a663ce012d897c223b25db36ca8382d1
+  :item:
+    citizen-names: Latvian
+    country: LV
+    name: Latvia
+    official-name: The Republic of Latvia
+    start-date: '1990-05-04'
+- :key: !ruby/string:RestClient::Response LB
+  :entry_number: 104
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d411b3c908d55f6f80daa30ad693c1ebe9f08dd5530365b0f62389b1a13cac94
+  :item:
+    citizen-names: Lebanese
+    country: LB
+    name: Lebanon
+    official-name: The Lebanese Republic
+- :key: !ruby/string:RestClient::Response LS
+  :entry_number: 105
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:7c0ff61a59fd3997ba2c9fb12565cf00d75ba8eccdf863aa76f092a244f9e2c7
+  :item:
+    citizen-names: Citizen of Lesotho
+    country: LS
+    name: Lesotho
+    official-name: The Kingdom of Lesotho
+- :key: !ruby/string:RestClient::Response LR
+  :entry_number: 106
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:bf65db91e00af3ab318e594047a245ea34402493847ddde2a141ddbb6d1d3445
+  :item:
+    citizen-names: Liberian
+    country: LR
+    name: Liberia
+    official-name: The Republic of Liberia
+- :key: !ruby/string:RestClient::Response LY
+  :entry_number: 107
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c1d32fcf8ee4a7f18c5765fddf3a6054ff003824f4e9b4882e43370f88811097
+  :item:
+    citizen-names: Libyan
+    country: LY
+    name: Libya
+    official-name: Libya
+- :key: !ruby/string:RestClient::Response LI
+  :entry_number: 108
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:065f76e9e547c6d8e915314a1b78337514fec0c264b555689e78ffd47acd9fec
+  :item:
+    citizen-names: Liechtenstein citizen
+    country: LI
+    name: Liechtenstein
+    official-name: The Principality of Liechtenstein
+- :key: !ruby/string:RestClient::Response LT
+  :entry_number: 109
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a9a56275429799939c8f38a189f203646efff235f1aa58510896a6d576b17742
+  :item:
+    citizen-names: Lithuanian
+    country: LT
+    name: Lithuania
+    official-name: The Republic of Lithuania
+    start-date: '1990-03-11'
+- :key: !ruby/string:RestClient::Response LU
+  :entry_number: 110
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:b00a1d254e6d187190abe43c8d87c76189d3e18a1c64ea88e365bfe75fe5508a
+  :item:
+    citizen-names: Luxembourger
+    country: LU
+    name: Luxembourg
+    official-name: The Grand Duchy of Luxembourg
+- :key: !ruby/string:RestClient::Response MK
+  :entry_number: 111
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:af8130b639bb8a675234c313dd763781a7da4e13b7529583d3a3a26c9f580fa7
+  :item:
+    citizen-names: Macedonian
+    country: MK
+    name: Macedonia
+    official-name: The Republic of Macedonia
+    start-date: '1991-09-08'
+- :key: !ruby/string:RestClient::Response MG
+  :entry_number: 112
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:22e2594c9b5845e2be21e27c0681132f0fbf7c38107c6da6d159f5b4626788c8
+  :item:
+    citizen-names: Citizen of Madagascar
+    country: MG
+    name: Madagascar
+    official-name: The Republic of Madagascar
+- :key: !ruby/string:RestClient::Response MW
+  :entry_number: 113
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:f920008062bcbdf4b131fda83452a53306458a79376678aa3f6f79dd82e0cce9
+  :item:
+    citizen-names: Malawian
+    country: MW
+    name: Malawi
+    official-name: The Republic of Malawi
+- :key: !ruby/string:RestClient::Response MY
+  :entry_number: 114
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:60e19a7cdbf3ab988827f7e9acacd3e2332f20ab884f9b131cdf43f6f5ea9c79
+  :item:
+    citizen-names: Citizen of Malaysia
+    country: MY
+    name: Malaysia
+    official-name: Malaysia
+- :key: !ruby/string:RestClient::Response MV
+  :entry_number: 115
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:f2a77c13d773efac02a5d06864b2bcf73bb310aa54819b6f000f3cf785042da3
+  :item:
+    citizen-names: Maldivian
+    country: MV
+    name: Maldives
+    official-name: The Republic of Maldives
+- :key: !ruby/string:RestClient::Response ML
+  :entry_number: 116
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:1502d9c3dd5d74d59f2d5d0f22c0a6b671c4e056041e20ca85b88fe4c937c75e
+  :item:
+    citizen-names: Malian
+    country: ML
+    name: Mali
+    official-name: The Republic of Mali
+- :key: !ruby/string:RestClient::Response MT
+  :entry_number: 117
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:441fe1136fa701eb9ed74b5bcaf2ac80058712d0146ea0d04f00f9df8eecf14b
+  :item:
+    citizen-names: Maltese
+    country: MT
+    name: Malta
+    official-name: The Republic of Malta
+- :key: !ruby/string:RestClient::Response MH
+  :entry_number: 118
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:541cd698077a663db8f45277a856fb3643304fcd2304aada085aab73505a9df3
+  :item:
+    citizen-names: Marshall Islander
+    country: MH
+    name: Marshall Islands
+    official-name: The Republic of the Marshall Islands
+    start-date: '1986-10-21'
+- :key: !ruby/string:RestClient::Response MR
+  :entry_number: 119
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:f45980872becc3957db957e35eb4e27b9cef3c313e3a94b375f95b3bd6fc72ab
+  :item:
+    citizen-names: Mauritanian
+    country: MR
+    name: Mauritania
+    official-name: The Islamic Republic of Mauritania
+- :key: !ruby/string:RestClient::Response MU
+  :entry_number: 120
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:63d01b2084c1abdc65c0bed65aef8c06b8c83b973ef88ee646535a0c1438cd22
+  :item:
+    citizen-names: Mauritian
+    country: MU
+    name: Mauritius
+    official-name: The Republic of Mauritius
+- :key: !ruby/string:RestClient::Response MX
+  :entry_number: 121
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:90a09c688085a772bd6441423768be6569a1cf9a07fefe781d7dd290586b2e7c
+  :item:
+    citizen-names: Mexican
+    country: MX
+    name: Mexico
+    official-name: The United Mexican States
+- :key: !ruby/string:RestClient::Response FM
+  :entry_number: 122
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:37106c73c01016740d6bf1e85e80824e9f3520c417df843f8f8c5920a07be322
+  :item:
+    citizen-names: Micronesian
+    country: FM
+    name: Micronesia
+    official-name: The Federated States of Micronesia
+    start-date: '1986-11-03'
+- :key: !ruby/string:RestClient::Response MD
+  :entry_number: 123
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:5c01391d74afde44cf4009333d79d031de97625e8709c9ba6c585c6b7d8c1e0d
+  :item:
+    citizen-names: Moldovan
+    country: MD
+    name: Moldova
+    official-name: The Republic of Moldova
+    start-date: '1991-08-27'
+- :key: !ruby/string:RestClient::Response MC
+  :entry_number: 124
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e341b8f5bbf862b956e81a86ac3e8f86c9ec3c64b9cf4dc048fcc666e09844c1
+  :item:
+    citizen-names: Monegasque
+    country: MC
+    name: Monaco
+    official-name: The Principality of Monaco
+- :key: !ruby/string:RestClient::Response MN
+  :entry_number: 125
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:67ea12cd877680cd4d0ecd268b89862eba47dac1c5ebe408629d16e4dbf25396
+  :item:
+    citizen-names: Mongolian
+    country: MN
+    name: Mongolia
+    official-name: Mongolia
+- :key: !ruby/string:RestClient::Response ME
+  :entry_number: 126
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d98c3da67cfba4c2c227a5d4e3301dcf9c2acfc4db05b2fba0661099e1e6372e
+  :item:
+    citizen-names: Montenegrin
+    country: ME
+    name: Montenegro
+    official-name: Montenegro
+- :key: !ruby/string:RestClient::Response MA
+  :entry_number: 127
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:3e9d91be962450c1fc5d72f515a74f42a4d2fa9bfd9631df8fa3cac0d1968487
+  :item:
+    citizen-names: Moroccan
+    country: MA
+    name: Morocco
+    official-name: The Kingdom of Morocco
+- :key: !ruby/string:RestClient::Response MZ
+  :entry_number: 128
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:85f0d2dbe778055ea732d0794269b0d2644ade5abdf38369af812a56aa970a03
+  :item:
+    citizen-names: Mozambican
+    country: MZ
+    name: Mozambique
+    official-name: The Republic of Mozambique
+    start-date: '1975-06-25'
+- :key: !ruby/string:RestClient::Response NA
+  :entry_number: 129
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:fe4265028d9164d9c15217a8903d45c41bf4a608584715e2f8897e4e58823b5b
+  :item:
+    citizen-names: Namibian
+    country: NA
+    name: Namibia
+    official-name: The Republic of Namibia
+    start-date: '1980-03-21'
+- :key: !ruby/string:RestClient::Response NR
+  :entry_number: 130
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:cd72b9665e571588335a83b4f35daac33796ce0d9b6abe40888b6567685ab36c
+  :item:
+    citizen-names: Nauruan
+    country: NR
+    name: Nauru
+    official-name: The Republic of Nauru
+- :key: !ruby/string:RestClient::Response NP
+  :entry_number: 131
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:114291b927f4189d866ecf6c3cddd0fbc908df838e73fd3c36711a5767cf97fd
+  :item:
+    citizen-names: Nepalese
+    country: NP
+    name: Nepal
+    official-name: The Federal Democratic Republic of Nepal
+- :key: !ruby/string:RestClient::Response NL
+  :entry_number: 132
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:b12534cbbfa6fc41cec278d4091c2f1c9de96532466e5b74937803bf84e2bd14
+  :item:
+    citizen-names: Dutch citizen;Dutchman;Dutchwoman
+    country: NL
+    name: Netherlands
+    official-name: The Kingdom of the Netherlands
+- :key: !ruby/string:RestClient::Response NZ
+  :entry_number: 133
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:a21357c7fbdb8ff03bee42853c97aa0f993cc12e65e55c48f5d5aea85adf70ad
+  :item:
+    citizen-names: New Zealander
+    country: NZ
+    name: New Zealand
+    official-name: New Zealand
+- :key: !ruby/string:RestClient::Response NI
+  :entry_number: 134
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:74316f67dff7d0bda653f30601824062a4354ad61edc698e99ce02a3aa065ea9
+  :item:
+    citizen-names: Nicaraguan
+    country: NI
+    name: Nicaragua
+    official-name: The Republic of Nicaragua
+- :key: !ruby/string:RestClient::Response NE
+  :entry_number: 135
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:77b37f9314a6b1310d59dfed862460f1a43c37213e780eca1c0a51dcbad4b452
+  :item:
+    citizen-names: Citizen of Niger
+    country: NE
+    name: Niger
+    official-name: The Republic of Niger
+- :key: !ruby/string:RestClient::Response NG
+  :entry_number: 136
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:790a98d2fb550158819bdbf744f53888f6f4a557f39df9cc814bf16de935c9eb
+  :item:
+    citizen-names: Nigerian
+    country: NG
+    name: Nigeria
+    official-name: The Federal Republic of Nigeria
+- :key: !ruby/string:RestClient::Response 'NO'
+  :entry_number: 137
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d5873302cd845c721f0da4d7f44a9502825c1d944ef6dc3057941c889258fbe0
+  :item:
+    citizen-names: Norwegian
+    country: 'NO'
+    name: Norway
+    official-name: The Kingdom of Norway
+- :key: !ruby/string:RestClient::Response OM
+  :entry_number: 138
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:fd9f928852ad89811c5e1387b030d463b8c35e59421c415b91b614c4cc314892
+  :item:
+    citizen-names: Omani
+    country: OM
+    name: Oman
+    official-name: The Sultanate of Oman
+- :key: !ruby/string:RestClient::Response PK
+  :entry_number: 139
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:23493ee9ddcd592719cfc04ca769dc3e8b06836d7119583cf2b11bb24fc9e978
+  :item:
+    citizen-names: Pakistani
+    country: PK
+    name: Pakistan
+    official-name: The Islamic Republic of Pakistan
+- :key: !ruby/string:RestClient::Response PW
+  :entry_number: 140
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d2078aa1d7670b9b99fca56a88b0e53b5267271ead9aa9dbd95de0440644416b
+  :item:
+    citizen-names: Palauan
+    country: PW
+    name: Palau
+    official-name: The Republic of Palau
+    start-date: '1994-10-01'
+- :key: !ruby/string:RestClient::Response PA
+  :entry_number: 141
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:4c1aee395ff77743bdd99a036d4573c527674fa4cdf2f085e3aa8cd99f22ce4e
+  :item:
+    citizen-names: Panamanian
+    country: PA
+    name: Panama
+    official-name: The Republic of Panama
+- :key: !ruby/string:RestClient::Response PG
+  :entry_number: 142
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e36519b5b0cb4556af87a0705ac7e4f53ab81e733d01e58965148c49f7eab82c
+  :item:
+    citizen-names: Papua New Guinean
+    country: PG
+    name: Papua New Guinea
+    official-name: The Independent State of Papua New Guinea
+    start-date: '1975-09-16'
+- :key: !ruby/string:RestClient::Response PY
+  :entry_number: 143
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ce57e3a16ba6645dac61bb4d997f13fbab3de1b0f1d0f592ac510ab94867ec7b
+  :item:
+    citizen-names: Paraguayan
+    country: PY
+    name: Paraguay
+    official-name: The Republic of Paraguay
+- :key: !ruby/string:RestClient::Response PE
+  :entry_number: 144
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:901dcacd3609e3adf154f509e553e2524fcdeaeb20f3871520d52c541ccc9fe3
+  :item:
+    citizen-names: Peruvian
+    country: PE
+    name: Peru
+    official-name: The Republic of Peru
+- :key: !ruby/string:RestClient::Response PH
+  :entry_number: 145
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:9202549fa85ecc1a72ce62d640a08cd296ab7dff834732decdcbb370b49b9293
+  :item:
+    citizen-names: Filipino;Filipina
+    country: PH
+    name: Philippines
+    official-name: The Republic of the Philippines
+- :key: !ruby/string:RestClient::Response PL
+  :entry_number: 146
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ecc388970f6c58a552f3b5c65847867d024d4a984a2e81a3f587cb829807d9c1
+  :item:
+    citizen-names: Pole
+    country: PL
+    name: Poland
+    official-name: The Republic of Poland
+- :key: !ruby/string:RestClient::Response PT
+  :entry_number: 147
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:237f7100bbbdcf670f0b0087a07350cd824007e230795acef6835883a68f9a37
+  :item:
+    citizen-names: Portuguese
+    country: PT
+    name: Portugal
+    official-name: The Portuguese Republic
+- :key: !ruby/string:RestClient::Response QA
+  :entry_number: 148
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:35759f269063ffedb40d97a1e61d0fba3a70bb005d459633e5da4155dd4ccfbb
+  :item:
+    citizen-names: Qatari
+    country: QA
+    name: Qatar
+    official-name: The State of Qatar
+- :key: !ruby/string:RestClient::Response RO
+  :entry_number: 149
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:63bd38f65b44e0fd32785668ed4cda1b9375b802df08aa23aa5934bcf291df74
+  :item:
+    citizen-names: Romanian
+    country: RO
+    name: Romania
+    official-name: Romania
+- :key: !ruby/string:RestClient::Response RU
+  :entry_number: 150
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:84cca8cb3b2b7862ea6fc1502ec93e46319e2eca1742a3272dd6e02fca5a90bd
+  :item:
+    citizen-names: Russian
+    country: RU
+    name: Russia
+    official-name: The Russian Federation
+    start-date: '1991-12-25'
+- :key: !ruby/string:RestClient::Response RW
+  :entry_number: 151
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:28f3129e67f9090a61d044bf39411f5689c3eaa4249ea8324e7c56d269daa9b0
+  :item:
+    citizen-names: Rwandan
+    country: RW
+    name: Rwanda
+    official-name: The Republic of Rwanda
+- :key: !ruby/string:RestClient::Response KN
+  :entry_number: 152
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:b1e504729906351725c3129717e8ffdb3d6c3f295d5bfa7e09d1985062fa0752
+  :item:
+    citizen-names: Citizen of St Christopher (St Kitts) and Nevis
+    country: KN
+    name: St Kitts and Nevis
+    official-name: The Federation of Saint Christopher and Nevis
+    start-date: '1983-09-19'
+- :key: !ruby/string:RestClient::Response LC
+  :entry_number: 153
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:80100f293b5b6e949af810887c84ebe7e79dfd030051a2cade595e3312413215
+  :item:
+    citizen-names: St Lucian
+    country: LC
+    name: St Lucia
+    official-name: Saint Lucia
+    start-date: '1979-02-22'
+- :key: !ruby/string:RestClient::Response VC
+  :entry_number: 154
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:4f741c4cfd4c81ad76f18601977c145138630219f92dd2570fb0495157a72554
+  :item:
+    citizen-names: Vincentian
+    country: VC
+    name: St Vincent
+    official-name: Saint Vincent and the Grenadines
+    start-date: '1979-10-27'
+- :key: !ruby/string:RestClient::Response WS
+  :entry_number: 155
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:bef4df153a794ff36ce8eb113c18360dc754af1a696058999b71376ece692237
+  :item:
+    citizen-names: Samoan
+    country: WS
+    name: Samoa
+    official-name: The Independent State of Samoa
+- :key: !ruby/string:RestClient::Response SM
+  :entry_number: 156
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:b9dd6114360f8ead867b7bc4b5e8c3c8aba891751510024f2db68c04c0a3a533
+  :item:
+    citizen-names: Citizen of San Marino
+    country: SM
+    name: San Marino
+    official-name: The Republic of San Marino
+- :key: !ruby/string:RestClient::Response ST
+  :entry_number: 157
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:5b140fa3611c6f1faa56fed779af7da604e2ade00f0da116f9e536bc2a7a3c17
+  :item:
+    citizen-names: Citizen of Sao Tome and Principe
+    country: ST
+    name: Sao Tome and Principe
+    official-name: The Democratic Republic of Sao Tome and Principe
+    start-date: '1975-07-12'
+- :key: !ruby/string:RestClient::Response SA
+  :entry_number: 158
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:7b2bbc9351ecfa03592952224ec189973c782986a3b6feaf3a6e372c3c94db54
+  :item:
+    citizen-names: Saudi Arabian
+    country: SA
+    name: Saudi Arabia
+    official-name: The Kingdom of Saudi Arabia
+- :key: !ruby/string:RestClient::Response SN
+  :entry_number: 159
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:69011cfeece3b537c677278239e1953f7a548a452c95452cdd2721fe9f66d658
+  :item:
+    citizen-names: Senegalese
+    country: SN
+    name: Senegal
+    official-name: The Republic of Senegal
+- :key: !ruby/string:RestClient::Response RS
+  :entry_number: 160
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:236a801b10320d3c9c4d26bfafd765986f9ae07f1cc12959aa81cf8aed8af243
+  :item:
+    citizen-names: Serbian
+    country: RS
+    name: Serbia
+    official-name: The Republic of Serbia
+- :key: !ruby/string:RestClient::Response SC
+  :entry_number: 161
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:37a4ad905de5f203642321eda62dee875ad72453ea15a04b55b6e7f7f912dd19
+  :item:
+    citizen-names: Citizen of Seychelles
+    country: SC
+    name: Seychelles
+    official-name: The Republic of Seychelles
+    start-date: '1976-06-29'
+- :key: !ruby/string:RestClient::Response SL
+  :entry_number: 162
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:30a05659fd604b1b3409babfc5d98e683813c34e52c98f4c83dc566747a43a32
+  :item:
+    citizen-names: Sierra Leonean
+    country: SL
+    name: Sierra Leone
+    official-name: The Republic of Sierra Leone
+- :key: !ruby/string:RestClient::Response SG
+  :entry_number: 163
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:3c8ee9ea8ba898a678cc10049a17f808a78e0d54af793363ae0201428c91b7d7
+  :item:
+    citizen-names: Singaporean
+    country: SG
+    name: Singapore
+    official-name: The Republic of Singapore
+- :key: !ruby/string:RestClient::Response SK
+  :entry_number: 164
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:92938c6db920eab9fdc4ccc0cf1ae113cd6d10d9be062b54ddf559e5d8000649
+  :item:
+    citizen-names: Slovak
+    country: SK
+    name: Slovakia
+    official-name: The Slovak Republic
+    start-date: '1993-01-01'
+- :key: !ruby/string:RestClient::Response SI
+  :entry_number: 165
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:3f3f84598f5715b91d06fa9755e43b52caf7b174e43a3499015cd56dd155d20b
+  :item:
+    citizen-names: Slovene
+    country: SI
+    name: Slovenia
+    official-name: The Republic of Slovenia
+    start-date: '1991-06-25'
+- :key: !ruby/string:RestClient::Response SB
+  :entry_number: 166
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:5b078885397e7f4983a73cfe84c9adb2e4ae638fbfd214ccb4e53c045f498a82
+  :item:
+    citizen-names: Solomon Islander
+    country: SB
+    name: Solomon Islands
+    official-name: Solomon Islands
+    start-date: '1978-07-07'
+- :key: !ruby/string:RestClient::Response SO
+  :entry_number: 167
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c4a7eaf6dc782bcd64e25120d05708ba71e29a7680f5e5a5406b6dae815f5edd
+  :item:
+    citizen-names: Somali
+    country: SO
+    name: Somalia
+    official-name: Federal Republic of Somalia
+- :key: !ruby/string:RestClient::Response ZA
+  :entry_number: 168
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:0577dbad39a261bf7978fad0ea17bf67858817ecc7047ba7edf1f28ca02b46b4
+  :item:
+    citizen-names: South African
+    country: ZA
+    name: South Africa
+    official-name: The Republic of South Africa
+- :key: !ruby/string:RestClient::Response SS
+  :entry_number: 169
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6524bf4347dd781b121c1e28fb36ced1568614918c7aff5b4d92da890c2ea049
+  :item:
+    citizen-names: South Sudanese
+    country: SS
+    name: South Sudan
+    official-name: The Republic of South Sudan
+    start-date: '2011-07-09'
+- :key: !ruby/string:RestClient::Response ES
+  :entry_number: 170
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:368f4923627e33fe4eef428f747fa0813a64eb43324bfc1aacb16a40dfa64f19
+  :item:
+    citizen-names: Spaniard;Spanish citizen
+    country: ES
+    name: Spain
+    official-name: The Kingdom of Spain
+- :key: !ruby/string:RestClient::Response LK
+  :entry_number: 171
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:9a5991d953e2859aa9758f97fc6662ddf2c680e8d23a5e2936cc4957fd853c7b
+  :item:
+    citizen-names: Citizen of Sri Lanka
+    country: LK
+    name: Sri Lanka
+    official-name: The Democratic Socialist Republic of Sri Lanka
+- :key: !ruby/string:RestClient::Response SD
+  :entry_number: 172
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:cc524b28c9b6d210c19b8f53a91e8d166c9d2f9ee316b22dc1f27ed35da34564
+  :item:
+    citizen-names: Sudanese
+    country: SD
+    name: Sudan
+    official-name: The Republic of the Sudan
+- :key: !ruby/string:RestClient::Response SR
+  :entry_number: 173
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:54444b35fc2d463178e371aea46ce67f4b08c90e0636b8580c911b34c9f1125a
+  :item:
+    citizen-names: Surinamer
+    country: SR
+    name: Suriname
+    official-name: The Republic of Suriname
+    start-date: '1975-11-25'
+- :key: !ruby/string:RestClient::Response SZ
+  :entry_number: 174
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d854e31c09e4487a8e607a141de81d2bc34b1ca9f6d60d505888801ee5fb3510
+  :item:
+    citizen-names: Swazi
+    country: SZ
+    name: Swaziland
+    official-name: The Kingdom of Swaziland
+- :key: !ruby/string:RestClient::Response SE
+  :entry_number: 175
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6a693202d812376dca679fca3d36f108653b8470556f7532177175e68efcc4b5
+  :item:
+    citizen-names: Swede
+    country: SE
+    name: Sweden
+    official-name: The Kingdom of Sweden
+- :key: !ruby/string:RestClient::Response CH
+  :entry_number: 176
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:8aa9b6292caa7ebbe1b5afe12fc2b307ed32e4ab822ba2c01a0ef10f8450baef
+  :item:
+    citizen-names: Swiss
+    country: CH
+    name: Switzerland
+    official-name: The Swiss Confederation
+- :key: !ruby/string:RestClient::Response SY
+  :entry_number: 177
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:03b3138d82567cf7c92542df724ce5deb38a9bf3ad65cc59f77023069cf65ef5
+  :item:
+    citizen-names: Syrian
+    country: SY
+    name: Syria
+    official-name: The Syrian Arab Republic
+- :key: !ruby/string:RestClient::Response TJ
+  :entry_number: 178
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:03d5a82e573cbaa7b95c71ba5b078f88ffe99b3e4b97952f4fa10e8fe6aeab17
+  :item:
+    citizen-names: Tajik
+    country: TJ
+    name: Tajikistan
+    official-name: The Republic of Tajikistan
+    start-date: '1991-09-09'
+- :key: !ruby/string:RestClient::Response TZ
+  :entry_number: 179
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e8340bff2deab287068524d6fb5feec1003365d25188eed72a8f3738bfa2ec7f
+  :item:
+    citizen-names: Tanzanian
+    country: TZ
+    name: Tanzania
+    official-name: The United Republic of Tanzania
+- :key: !ruby/string:RestClient::Response TH
+  :entry_number: 180
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d2573565cb9155bf24ac971c578867c5b10610b7dd558211f9df30244d68216f
+  :item:
+    citizen-names: Thai
+    country: TH
+    name: Thailand
+    official-name: The Kingdom of Thailand
+- :key: !ruby/string:RestClient::Response TG
+  :entry_number: 181
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:ecadf144a77778b83e5c47718a8e383e0ec9d1e1652b3e1f0825f64611b9dfbf
+  :item:
+    citizen-names: Togolese
+    country: TG
+    name: Togo
+    official-name: The Togolese Republic
+- :key: !ruby/string:RestClient::Response TO
+  :entry_number: 182
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:60bf05eff5a3902a0a770fb844e25c918e0b016ea92a1d017b9dd8b944a16388
+  :item:
+    citizen-names: Tongan
+    country: TO
+    name: Tonga
+    official-name: The Kingdom of Tonga
+- :key: !ruby/string:RestClient::Response TT
+  :entry_number: 183
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6f630356cbaa6e96ed592b26bb6ba707826fd95e1500875ca4010b1067666221
+  :item:
+    citizen-names: Trinidad and Tobago citizen
+    country: TT
+    name: Trinidad and Tobago
+    official-name: The Republic of Trinidad and Tobago
+- :key: !ruby/string:RestClient::Response TN
+  :entry_number: 184
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:e6980aee1234069dcb6188a681696ddda7c33fb3562d69ea0be0d53f2906abc4
+  :item:
+    citizen-names: Tunisian
+    country: TN
+    name: Tunisia
+    official-name: The Tunisian Republic
+- :key: !ruby/string:RestClient::Response TR
+  :entry_number: 185
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:547035e601ee8d0277fc11ea87fd4cf5e200c7a8d7c1d91591bb718cf410f846
+  :item:
+    citizen-names: Turk
+    country: TR
+    name: Turkey
+    official-name: The Republic of Turkey
+- :key: !ruby/string:RestClient::Response TM
+  :entry_number: 186
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:15d6ad4b828394e5db3b24cf15277eed51f6ccbe936d71fd583e071159370e16
+  :item:
+    citizen-names: Turkmen
+    country: TM
+    name: Turkmenistan
+    official-name: Turkmenistan
+    start-date: '1991-10-27'
+- :key: !ruby/string:RestClient::Response TV
+  :entry_number: 187
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:f18ade1035a53da478ad84ca73209128fdecc5b4234bde9e37bdbf5e60670dd7
+  :item:
+    citizen-names: Tuvaluan
+    country: TV
+    name: Tuvalu
+    official-name: Tuvalu
+    start-date: '1978-10-01'
+- :key: !ruby/string:RestClient::Response UG
+  :entry_number: 188
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:c799ac9946bed4885c3e57abce00bbc4700ea9a95b1f65c9fdb88533aa64d47b
+  :item:
+    citizen-names: Ugandan
+    country: UG
+    name: Uganda
+    official-name: The Republic of Uganda
+- :key: !ruby/string:RestClient::Response UA
+  :entry_number: 189
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:3413d164924f47d3b6b8618a5de30a53b8b8b692bded4f16203090c0808b1e99
+  :item:
+    citizen-names: Ukrainian
+    country: UA
+    name: Ukraine
+    official-name: Ukraine
+    start-date: '1991-08-24'
+- :key: !ruby/string:RestClient::Response AE
+  :entry_number: 190
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d46c998e0013d1de0734132b26d99fdd638dccb8de4c4a88451af88579120844
+  :item:
+    citizen-names: Citizen of the United Arab Emirates
+    country: AE
+    name: United Arab Emirates
+    official-name: The United Arab Emirates
+- :key: !ruby/string:RestClient::Response US
+  :entry_number: 191
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:0abbabb7b2c3259dc326a23cf21ef2ed1b39b1d70973c64b293ffbeff351a3fe
+  :item:
+    citizen-names: United States citizen
+    country: US
+    name: United States
+    official-name: The United States of America
+- :key: !ruby/string:RestClient::Response UY
+  :entry_number: 192
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:bf953faff6c89f0085e220605bbbb8f5ad12d8c53bcc320237b20f554db78eab
+  :item:
+    citizen-names: Uruguayan
+    country: UY
+    name: Uruguay
+    official-name: The Oriental Republic of Uruguay
+- :key: !ruby/string:RestClient::Response UZ
+  :entry_number: 193
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:6d37b260df22e583623a29b06f75957661f3baea526964990b8e97beac8a0a35
+  :item:
+    citizen-names: Uzbek
+    country: UZ
+    name: Uzbekistan
+    official-name: The Republic of Uzbekistan
+    start-date: '1991-09-01'
+- :key: !ruby/string:RestClient::Response VU
+  :entry_number: 194
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:619ad0bf5aa6c8125569d89656e01cb70cf16cc489c048dfbd7de536fe0eeb67
+  :item:
+    citizen-names: Citizen of Vanuatu
+    country: VU
+    name: Vanuatu
+    official-name: The Republic of Vanuatu
+    start-date: '1980-07-30'
+- :key: !ruby/string:RestClient::Response VA
+  :entry_number: 204
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:466d194d5100532edd115e3f0035967b09bc7b7f5fc444166df6f4a5f7cb9127
+  :item:
+    citizen-names: Vatican citizen
+    country: VA
+    name: Vatican City
+    official-name: Vatican City State
+- :key: !ruby/string:RestClient::Response VE
+  :entry_number: 196
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:50649b40f1bb4ae51431aec9be3f57cd2dd4a6f642f3471d3940bb2669292ed8
+  :item:
+    citizen-names: Venezuelan
+    country: VE
+    name: Venezuela
+    official-name: The Bolivarian Republic of Venezuela
+- :key: !ruby/string:RestClient::Response VN
+  :entry_number: 197
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:15e0d6355b2e1bc664a719470a3061823b748b83abd54c3acc37eadcecd77511
+  :item:
+    citizen-names: Vietnamese
+    country: VN
+    name: Vietnam
+    official-name: The Socialist Republic of Vietnam
+- :key: !ruby/string:RestClient::Response YE
+  :entry_number: 198
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:3fce9c67e4581d895712a6ef1e7f3020f34bf80baad04413e25d8677b972b1e4
+  :item:
+    citizen-names: Yemeni
+    country: YE
+    name: Yemen
+    official-name: The Republic of Yemen
+    start-date: '1990-05-22'
+- :key: !ruby/string:RestClient::Response ZM
+  :entry_number: 199
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:4dbf7919be59e1477ef719637d335666f5d54e272f6440abeae3519a45031433
+  :item:
+    citizen-names: Zambian
+    country: ZM
+    name: Zambia
+    official-name: The Republic of Zambia
+- :key: !ruby/string:RestClient::Response ZW
+  :entry_number: 200
+  :timestamp: !ruby/string:RestClient::Response '2016-04-05T13:23:05Z'
+  :hash: !ruby/string:RestClient::Response sha-256:d42acdfd107649a25563ca1eb9af0e92b034951c63983c431e77400daeefd2c8
+  :item:
+    citizen-names: Zimbabwean
+    country: ZW
+    name: Zimbabwe
+    official-name: The Republic of Zimbabwe
+    start-date: '1980-04-18'


### PR DESCRIPTION
Refactor Key Uniqueness Validator to use `EachValidator` which simplifies the code and only runs the validator against the key field, adds a test.