### PR TITLE
make datetime validation more strict

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'cancancan'
 
 # form helpers
 gem 'nested_form_fields'
+gem 'timeliness', '~> 0.3.8'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timeliness (0.3.8)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -347,6 +348,7 @@ DEPENDENCIES
   sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
+  timeliness (~> 0.3.8)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock

--- a/app/validators/datetime_validator.rb
+++ b/app/validators/datetime_validator.rb
@@ -1,9 +1,11 @@
+require 'timeliness'
+
 class DatetimeValidator < ActiveModel::EachValidator
-  YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS_UTC = '%Y-%m-%dT%H:%M:%SZ'
-  YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS = '%Y-%m-%dT%H:%M:%S'
-  YEAR_MONTH_DAY = '%Y-%m-%d'
-  YEAR_MONTH = '%Y-%m'
-  YEAR = '%Y'
+  YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS_UTC = 'yyyy-mm-ddThh:nn:ssZ'
+  YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS = 'yyyy-mm-ddThh:nn:ss'
+  YEAR_MONTH_DAY = 'yyyy-mm-dd'
+  YEAR_MONTH = 'yyyy-mm'
+  YEAR = 'yyyy'
   DATE_FORMATS = [
       YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS_UTC,
       YEAR_MONTH_DAY_HOURS_MINUTES_SECONDS,
@@ -13,14 +15,7 @@ class DatetimeValidator < ActiveModel::EachValidator
   ].freeze
 
   def valid_date(value)
-    DATE_FORMATS.each { |date_format|
-      begin
-        Date.strptime(value, date_format)
-        return true
-      rescue ArgumentError
-      end
-    }
-    false
+    DATE_FORMATS.any? { |f| Timeliness.parse(value, format: f) }
   end
 
   def validate_each(record, attribute, value)

--- a/spec/helpers/validation_helper_spec.rb
+++ b/spec/helpers/validation_helper_spec.rb
@@ -20,13 +20,17 @@ RSpec.describe ValidationHelper do
     end
 
     it 'returns an error if date is invalid' do
-      params = { 'start-date' => 'foo', 'country' => 'zz' }
-      expect(data_validator.get_form_errors(params, field_definitions, 'country', nil).messages).to eql(start_date: ['Enter a valid date'])
+      ['X123', '123X', 'foo', '20145', '201'].each do |d|
+        params = { 'start-date' => d, 'country' => 'zz' }
+        expect(data_validator.get_form_errors(params, field_definitions, 'country', nil).messages).to eql(start_date: ['Enter a valid date'])
+      end
     end
 
     it 'returns no errors if date is valid' do
-      params = { 'start-date' => '2015-05', 'country' => 'xx' }
-      expect(data_validator.get_form_errors(params, field_definitions, 'country', nil).details).to be_empty
+      ['2014', '2014-05', '2014-05-01', '2017-10-19T08:10:49', '2017-10-19T08:10:49Z'].each do |d|
+        params = { 'start-date' => d, 'country' => 'xx' }
+        expect(data_validator.get_form_errors(params, field_definitions, 'country', nil).details).to be_empty
+      end
     end
 
     it 'returns an error if key is not populated' do


### PR DESCRIPTION
...turns out `Date.strptime` is a very loose validator e.g.
```
 Date.strptime('123X', '%Y')
 => #<Date: 0123-01-01 ((1765984j,0s,0n),+0s,2299161j)> 
```
😱 
This PR switches to `timeliness` gem which offers strict format validation and does not require us to catch any exception.

fixes #79