### PR TITLE
Always show register input when inviting custodian

### DIFF
--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -70,3 +70,11 @@
 
   .form-group
     = f.submit "Send invite", class: 'button'
+
+- content_for :javascript do
+  :javascript
+    $(function() {
+      if ($('.nested_fields').length < 2) {
+        $('.remove_nested_fields_link').hide()
+      }
+    })


### PR DESCRIPTION
Fixes #59 but doesn’t fix the actual inviting bug

# After - remove link is hidden for first input

![screen shot 2017-10-20 at 14 34 55](https://user-images.githubusercontent.com/3071606/31823373-e38f85a6-b5a3-11e7-8e6a-2622b271287d.png)
![screen shot 2017-10-20 at 14 35 01](https://user-images.githubusercontent.com/3071606/31823372-e370aaaa-b5a3-11e7-8c82-eb8b1b19145f.png)

