### PR TITLE
Add custodian permissions and clean up page titles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -267,6 +267,6 @@ table {
 }
 
 .panel-border-narrow {
-  padding: 0 0.7894736842em 0 0.7894736842em;
+  padding: 0 20px;
   margin-bottom: 40px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -168,10 +168,6 @@ table {
 }
 
 .user {
-  &__permissions {
-    color: $grey-1;
-  }
-
   &__name {
     font-weight: 700;
 
@@ -268,4 +264,9 @@ table {
   padding: 4px 8px 2px 8px;
   margin-left: 10px;
   vertical-align: middle;
+}
+
+.panel-border-narrow {
+  padding: 0 0.7894736842em 0 0.7894736842em;
+  margin-bottom: 40px;
 }

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -4,13 +4,8 @@
 - if params[:role] == 'admin'
   = link_to 'Back', admin_path, class: 'link-back'
 
-- if params[:team_id]
-  = link_to 'Back', team_path(params[:team_id]), class: 'link-back'
-
-%h1.heading-large= t('devise.invitations.new.header')
-
-- if params[:role] == 'admin'
-  .user__permissions
+  %h1.heading-large Add a new admin
+  .panel.panel-border-narrow
     %p.list-title All Admin users can:
     %ul.list.list-bullet
       %li Manage Admin team
@@ -18,6 +13,23 @@
       %li Update records
       %li Submit updates for review
       %li Approve and publish updates to records
+
+- if params[:role] == 'custodian'
+  = link_to 'Back', custodians_path, class: 'link-back'
+
+  %h1.heading-large Add a new custodian
+  .panel.panel-border-narrow
+    %p.list-title Custodians are responsible for registers and they can:
+    %ul.list.list-bullet
+      %li Manage team members
+      %li Update records
+      %li Submit updates for review
+      %li Approve and publish updates to records
+
+- if params[:team_id]
+  = link_to 'Back', team_path(params[:team_id]), class: 'link-back'
+
+  %h1.heading-large Add a new team member
 
 = form_for resource, url: invitation_path(resource_name), html: { method: :post } do |f|
 


### PR DESCRIPTION
Fixes #57, adds back button to custodian invite and separate pages title depending on type

![screen shot 2017-10-20 at 14 54 31](https://user-images.githubusercontent.com/3071606/31824415-d8ffde08-b5a6-11e7-9622-abbabe70ceca.png)
![screen shot 2017-10-20 at 14 53 38](https://user-images.githubusercontent.com/3071606/31824416-d91930f6-b5a6-11e7-8293-dcb007ac35d0.png)
![screen shot 2017-10-20 at 14 53 31](https://user-images.githubusercontent.com/3071606/31824417-d9431baa-b5a6-11e7-896b-b2df370cb567.png)
