### PR TITLE
Update openregister-ruby to v0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'govuk_elements_rails'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder'
 
 # Ruby client for OpenRegisters
-gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby-client', tag: 'v0.1.0'
+gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby-client', tag: 'v0.2.1'
 
 # Email and Text Notifications
 gem 'govuk_notify_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,11 @@ GIT
 
 GIT
   remote: https://github.com/openregister/openregister-ruby-client
-  revision: 6769a5123d30bc800a40f39a08072fa3be6b31ce
-  tag: v0.1.0
+  revision: 8924f3b8cbb76548f334bb66c8cb9010634366f2
+  tag: v0.2.1
   specs:
-    openregister-ruby (0.1.0)
+    openregister-ruby (0.2.1)
+      mini_cache (~> 1.1.0)
       morph (~> 0.5.0)
       rest-client (~> 2)
 
@@ -168,6 +169,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_cache (1.1.0)
     mini_mime (0.1.4)
     mini_portile2 (2.3.0)
     minitest (5.10.3)

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -35,8 +35,8 @@ class RegisterController < ApplicationController
 
   def confirm
     register_name = params[:register].downcase
-    field_definitions = @registers_client.get_register(register_name, 'beta').get_field_definitions
-    records = @registers_client.get_register(register_name, 'beta').get_records
+    field_definitions = @@registers_client.get_register(register_name, 'beta').get_field_definitions
+    records = @@registers_client.get_register(register_name, 'beta').get_records
     validation_result = @data_validator.get_form_errors(params, field_definitions, register_name, records)
     if validation_result.messages.present?
       validation_result.messages.each { |k,v| flash.now[k] = v.join(', ') }
@@ -88,7 +88,7 @@ class RegisterController < ApplicationController
         Rails.env.development? || response = RegisterPost.(@change.register_name, rsf_body)
 
         if Rails.env.development? || Rails.env.staging? || response.code == '200'
-          @registers_client.get_register(@change.register_name, Rails.configuration.register_phase.to_s).refresh_data
+          @@registers_client.get_register(@change.register_name, Rails.configuration.register_phase.to_s).refresh_data
           flash[:notice] = 'The record has been published.'
           redirect_to controller: 'register', action: 'index', register: params[:register]
         else
@@ -112,6 +112,6 @@ class RegisterController < ApplicationController
 
   def initialize_controller
     @data_validator = ValidationHelper::DataValidator.new
-    @registers_client = OpenRegister::RegistersClient.new
+    @@registers_client ||= OpenRegister::RegistersClient.new({ cache_duration: 60 })
   end
 end

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -112,6 +112,6 @@ class RegisterController < ApplicationController
 
   def initialize_controller
     @data_validator = ValidationHelper::DataValidator.new
-    @@registers_client ||= OpenRegister::RegistersClient.new({ cache_duration: 60 })
+    @@registers_client ||= OpenRegister::RegistersClient.new({ cache_duration: Rails.configuration.cache_duration })
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,4 +65,6 @@ Rails.application.configure do
   config.register_ssl = false
   config.register_phase = :test
 
+  config.cache_duration = 3600
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,4 +92,6 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'https://managing-registers.cloudapps.digital' }
 
   config.register_phase = :beta
+
+  config.cache_duration = 3600
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -88,4 +88,6 @@ Rails.application.configure do
   config.register_phase = :test
   config.register_url = 'test.openregister.org/load-rsf'
   config.register_ssl = true
+
+  config.cache_duration = 3600
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,4 +49,6 @@ Rails.application.configure do
 
   config.register_url = 'test.openregister.org/load-rsf'
   config.register_ssl = false
+
+  config.cache_duration = 3600
 end


### PR DESCRIPTION
This commit updates openregister-ruby to v0.2.1, which includes functionality to cache register data for a set period of time after it is downloaded. The cache duration, which controls this period of time that the data lives for, is overridden in this commit to be one minute.