### PR TITLE
fix reject email notification

### DIFF
--- a/app/mailers/register_updates_mailer.rb
+++ b/app/mailers/register_updates_mailer.rb
@@ -35,7 +35,7 @@ class RegisterUpdatesMailer < GovukNotifyRails::Mailer
       reason_declined: change.status.comment
     )
 
-    mail(from: user.email)
+    mail(to: change.user.email)
   end
 
   def register_update_approved(change, user)


### PR DESCRIPTION
fixes #83 
Mailer was missing mandatory `to` field.