### PR TITLE
Application crash when registering a name already registered

### DIFF
--- a/db/migrate/20171025082349_alter_index_users_on_full_name.rb
+++ b/db/migrate/20171025082349_alter_index_users_on_full_name.rb
@@ -1,0 +1,6 @@
+class AlterIndexUsersOnFullName < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :users, :full_name
+    add_index :users, :full_name
+  end
+end


### PR DESCRIPTION
Removing the `unique` constraint in the `full_name` index because it enforces the uniqueness of the values in the column of the table.

There is not apparent side effect but we need to pay attention just in case the library 'DeviseInvitable' assume this restriction in some query or operation.