### PR TITLE
Application crash when registering a name already registered

### DIFF
--- a/db/migrate/20171025090217_alter_index_users_full_name_unique_constraint.rb
+++ b/db/migrate/20171025090217_alter_index_users_full_name_unique_constraint.rb
@@ -1,0 +1,6 @@
+class AlterIndexUsersFullNameUniqueConstraint < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :users, :full_name
+    add_index :users, :full_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622164850) do
+ActiveRecord::Schema.define(version: 20171025090217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20170622164850) do
     t.string   "full_name"
     t.boolean  "admin",                  default: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["full_name"], name: "index_users_on_full_name", unique: true, using: :btree
+    t.index ["full_name"], name: "index_users_on_full_name", using: :btree
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
     t.index ["invitations_count"], name: "index_users_on_invitations_count", using: :btree
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree


### PR DESCRIPTION
Removing the `unique` constraint in the `full_name` index because it enforces the uniqueness of the values in the column of the table.

There is not apparent side effect but we need to pay attention just in case the library 'DeviseInvitable' assume this restriction in some query or operation.