### PR TITLE
Validate presence of role & email fields

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,6 +57,7 @@ class UsersController::InvitationsController < Devise::InvitationsController
   include ElevatedPermissionsHelper
 
   def create
+    # TODO use rails validators for these checks
     begin
       params.require(:user).require(:email)
     rescue ActionController::ParameterMissing

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -36,8 +36,7 @@
   - resource.class.invite_key_fields.each do |field|
     .grid-row
       .column-one-half
-        = f.text_field field, class: 'form-control-full-width'
-
+        = f.text_field field, class: 'form-control-full-width', :required => true
   - if params[:role] == 'admin'
     = f.hidden_field :admin, value: true
   - else
@@ -63,7 +62,7 @@
           %fieldset
             %legend.visually-hidden= t('views.users.role')
             .multiple-choice
-              = tm.radio_button :role, "advanced"
+              = tm.radio_button :role, "advanced", :required => true
               = tm.label :role, "Advanced", value: "advanced"
             .user__permissions
               %p.list-title Advanced can:

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -17,7 +17,7 @@
 - if params[:role] == 'custodian'
   = link_to 'Back', custodians_path, class: 'link-back'
 
-  %h1.heading-large Add a new custodian
+  %h1.heading-large Add a new   
   .panel.panel-border-narrow
     %p.list-title Custodians are responsible for registers and they can:
     %ul.list.list-bullet
@@ -36,7 +36,7 @@
   - resource.class.invite_key_fields.each do |field|
     .grid-row
       .column-one-half
-        = f.text_field field, class: 'form-control-full-width', 'required': true
+        = f.text_field field, class: 'form-control-full-width', 'required': true, 'type': (field == :email ? 'email': nil)
   - if params[:role] == 'admin'
     = f.hidden_field :admin, value: true
   - else

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -36,7 +36,7 @@
   - resource.class.invite_key_fields.each do |field|
     .grid-row
       .column-one-half
-        = f.text_field field, class: 'form-control-full-width', :required => true
+        = f.text_field field, class: 'form-control-full-width', 'required': true
   - if params[:role] == 'admin'
     = f.hidden_field :admin, value: true
   - else
@@ -62,7 +62,7 @@
           %fieldset
             %legend.visually-hidden= t('views.users.role')
             .multiple-choice
-              = tm.radio_button :role, "advanced", :required => true
+              = tm.radio_button :role, "advanced", 'required': true
               = tm.label :role, "Advanced", value: "advanced"
             .user__permissions
               %p.list-title Advanced can:


### PR DESCRIPTION
fixes #128 
fixes #110 

Check on the client and server side that the email and role fields are populated before processing the invitation. This supersedes #118