### PR TITLE
Zero downtime deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ rvm:
 
 cache: bundler
 
+env:
+  global:
+  - CF_API="https://api.cloud.service.gov.uk"
+  - CF_ORG="openregister"
+  - CF_SPACE="sandbox"
+  - CF_USERNAME="register-design-authority@digital.cabinet-office.gov.uk"
+
 services:
   - postgresql
 
@@ -13,15 +20,18 @@ before_script:
 script:
   - bundle exec rake spec
 
+before_deploy:
+  - export PATH=$HOME:$PATH
+  # Install CloudFoundry
+  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
+  - tar xzvf $HOME/cf.tgz -C $HOME
+  # Install Autopilot plugin for zero-downtime-push
+  - travis_retry cf install-plugin autopilot -f -r CF-Community
+
 deploy:
-  provider: cloudfoundry
-  api: https://api.cloud.service.gov.uk
-  username: register-design-authority@digital.cabinet-office.gov.uk
-  password:
-    secure: gy9ZYI71J42WD+OQJH/KSqkJEGXG1X0iyNmdMpY3MKSK9+mOzplpqLV3Y0FJP6J8/Tr27GNoB8GYBja4BDswt4yRdHMYkly7ok36G+UPEST/dDPSZzzgYooyNREKPPQpT2oLqQ9GuByyiZ2wbl2PyACZXtRK5ajefco+Ca1YBaCazPVw4uMT0mMRw3MHKYcHNITqosZDt3MGfa769Nq7rGD0dL8T7HYLlluVfyqoNxZfMUKcfyelHRcrGeiw3iAX9b06OGZn3sLXqzdGq9wp4ztTO6UgDYju7EHyrkI35LkKnjD7gwjhqq3lk5aNiZNXM3SPvhtrWAK9d0ULCWAO+JXNe/ExKAjbrKYffrx+ShDRA0Xyn6X+WdpNaBbohcbAZoEV5HFFT/VDkyAkOO3v05Qt8Vnq5xpo31NffVOGW0qWRS89upT4pwZSedyE+ghiutOGYJA0Y0UDBXtFCOmYfBEkFcfJE3iXplVz/FVBeGV6JV2fbJIzwpbkOCtoPYn/k5UaHxYgGAqp437dRO5LLS86s4bs4wldX9mmIlwlCGBvSDgqWQ0FcGujNN2r1jiiAM63V1R9IsXOrEllADgqw+FNTcZfubiB8+3Opeic+rW34PL5UP/IlZeL2FfIuaS8BOiVgb7bh5lugiTlJTxQL79UATPKCTurj25UaZeChmg=
-  organization: openregister
-  space: sandbox
-  manifest: manifest-staging.yml
+  provider: script
+  script: chmod +x ./bin/deploy staging
+  skip_cleanup: true
   on:
     repo: openregister/managing-registers
     branch: master

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'cancancan'
 gem 'nested_form_fields'
 gem 'timeliness', '~> 0.3.8'
 
+# cloudfoundry
+gem 'cf-app-utils', '~> 0.6'
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cf-app-utils (0.6)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -326,6 +327,7 @@ DEPENDENCIES
   binding_of_caller
   cancancan
   capybara
+  cf-app-utils (~> 0.6)
   database_cleaner
   devise
   devise_invitable

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+# Default to staging but overridable by argument
+ENVIRONMENT=${1:-staging}
+
+# Parse app name from manifest to ensure it matches up
+APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest-base.yml'); puts config['applications'][0]['name']")
+
+echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
+
+# $CF env variables are set by Travis and configured in ../.travis.yml
+cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+
+# Zero downtime push comes from "Autopilot" which is installed in before_deploy
+# step in Travis
+cf zero-downtime-push $APP_NAME -f manifest-${ENVIRONMENT}.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ require "sprockets/railtie"
 
 # Openregister gem
 require 'openregister'
+require 'cf-app-utils'
+
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -18,6 +20,13 @@ Bundler.require(*Rails.groups)
 
 module CustodianUpdateTool
   class Application < Rails::Application
+    if ENV.key?('VCAP_SERVICES')
+      cups_env = CF::App::Credentials.find_by_service_name('managing-registers-environment-variables')
+      if cups_env.present?
+        cups_env.each { |k, v| ENV[k] = v }
+      end
+    end
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 

--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -8,3 +8,6 @@ applications:
   - name: managing-registers
     health-check-type: http
     health-check-http-endpoint: /health_check/standard
+
+services:
+   - managing-registers-environment-variables

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -4,3 +4,5 @@ inherit: manifest-base.yml
 
 routes:
   - route: managing-registers-staging.cloudapps.digital
+services:
+  - managing-registers-staging


### PR DESCRIPTION
Implement zero downtime deploys using a similar strategy to https://github.com/openregister/register-status

* Read environment variables externally using [CUPS](https://docs.cloudfoundry.org/devguide/services/user-provided.html#deliver-service-credentials-to-an-application) 
* Zero downtime deploy using [autopilot](https://github.com/contraband/autopilot)