### PR TITLE
override env vars in staging

### DIFF
--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -6,3 +6,6 @@ routes:
   - route: managing-registers-staging.cloudapps.digital
 services:
   - managing-registers-staging
+env:
+  RAILS_ENV: staging  
+  RACK_ENV: staging  


### PR DESCRIPTION
We need to set these environment variables to override those [set by default by the Ruby Buildpack](https://docs.cloudfoundry.org/buildpacks/ruby/ruby-environment.html)
