### PR TITLE
fix erroneous chmod when deploying from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_deploy:
 
 deploy:
   provider: script
-  script: chmod +x ./bin/deploy
+  script: ./bin/deploy staging
   skip_cleanup: true
   on:
     repo: openregister/managing-registers


### PR DESCRIPTION
We were erroneously running `chmod` on the file instead of executing it when deploying.
This fixes deployment from Travis.

*(H/T @camelpunch for spotting this)*