### PR TITLE
Upgrade from Factory Girl to Factory Bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,11 +51,11 @@ gem 'timeliness', '~> 0.3.8'
 gem 'cf-app-utils', '~> 0.6'
 
 group :development, :test do
-  gem 'pry-byebug'
-  gem 'rspec-rails', '~> 3.5'
   gem 'capybara'
+  gem 'factory_bot_rails', '~> 4.8', '>= 4.8.2'
+  gem 'pry-byebug'
   gem 'rails-controller-testing'
-  gem 'factory_bot_rails'
+  gem 'rspec-rails', '~> 3.5'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.5'
   gem 'capybara'
   gem 'rails-controller-testing'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise_invitable
-  factory_bot_rails
+  factory_bot_rails (~> 4.8, >= 4.8.2)
   faker
   govuk_elements_form_builder!
   govuk_elements_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,10 +109,10 @@ GEM
     erubi (1.7.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.8.1)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
@@ -331,7 +331,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise_invitable
-  factory_girl_rails
+  factory_bot_rails
   faker
   govuk_elements_form_builder!
   govuk_elements_rails

--- a/spec/factories/registers.rb
+++ b/spec/factories/registers.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :register do
     key 'country'
     association :team

--- a/spec/factories/team_members.rb
+++ b/spec/factories/team_members.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :team_member do
     role 'custodian'
     association :team

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :team do
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     full_name { Faker::Name.name }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'database_cleaner'
 require 'capybara/rails'
 require 'capybara/rspec'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 require 'webmock/rspec'
 
 # Ensure we can’t make external requests
@@ -26,7 +26,7 @@ WebMock.disable_net_connect!(allow_localhost: true)
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:each) do
     stub_request(:get, /beta.openregister.org/).


### PR DESCRIPTION
Fixes Deprecation Warning:
```
DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot. See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions. (called from require at /Users/gideongoldberg/.rvm/gems/ruby-2.4.2@custodian_update_tool/gems/bundler-1.15.4/lib/bundler/runtime.rb:82)
```