### PR TITLE
only hide invite form if role custodian and no unsassigned registers

### DIFF
--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -30,9 +30,9 @@
   = link_to 'Back', team_path(params[:team_id]), class: 'link-back'
 
   %h1.heading-large Add a new team member
-- has_unassigned_registers = (Register.all.map(&:key) - (registers_by_name)).present?
+- no_unassigned_registers = (Register.all.map(&:key) - (registers_by_name)).empty?
 
-- if has_unassigned_registers
+- unless no_unassigned_registers && params[:role] == 'custodian'
   = form_for resource, url: invitation_path(resource_name), html: { method: :post } do |f|
 
     - resource.class.invite_key_fields.each do |field|


### PR DESCRIPTION
The check added in #165 was erroneously hiding the form for other invite types e.g. admin.