### PR TITLE
Add production database service binding

### DIFF
--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -11,3 +11,4 @@ applications:
 
 services:
    - managing-registers-environment-variables
+   - logit-ssl-drain

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -6,4 +6,6 @@ routes:
   - route: managing-registers-production.cloudapps.digital
   - route: managing-registers.cloudapps.digital
 env:
-  UA_TRACKING_ID: UA-86101042-5
+  UA_TRACKING_ID: UA-86101042-5 
+services:
+  - managing-registers-production

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -6,7 +6,6 @@ routes:
   - route: managing-registers-staging.cloudapps.digital
 services:
   - managing-registers-staging
-  - logit-ssl-drain
 env:
   RAILS_ENV: staging
   RACK_ENV: staging


### PR DESCRIPTION
Add production database service binding. This is a prerequisite of zero downtime deploys to production. Also move logit to base as it is shared between environments.