### PR TITLE
Fix custodian list view

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,14 +16,7 @@ class UsersController < ApplicationController
 
   def custodians
     check_permissions(:USERS_CUSTODIANS, current_user: current_user)
-
-    @custodians = User.joins(:team_members)
-                      .where(team_members: { role: 'custodian' })
-                      .where.not(invitation_accepted_at: nil)
-
-    @pending_custodians = User.joins(:team_members)
-                              .where(team_members: { role: 'custodian' })
-                              .where(invitation_accepted_at: nil)
+    @teams = Team.all
   end
 
   def update; end

--- a/app/views/users/custodians.html.haml
+++ b/app/views/users/custodians.html.haml
@@ -31,18 +31,19 @@
             %th Registers
             %th
         %tbody
-          - if @custodians.present?
-            - @custodians.each do |custodian|
-              %tr{class: "js-filter-item", "data-filter-terms" => "#{custodian.try(:full_name)} #{custodian.email}"}
-                %td
-                  %span.user__name
-                    = custodian.full_name
-                %td= custodian.email
-                %td
-                  - custodian.team_members.first.team.registers.each do |register|
-                    %span.user__register-name= prepare_register_name(register.key)
-                %td
-                  = link_to 'View team', team_path(custodian.team_members.where(role: 'custodian').last.team_id)
+          - if @teams.present?
+            - @teams.each do |team|
+              - if team.custodian.invitation_accepted_at.present?
+                %tr{class: "js-filter-item", "data-filter-terms" => "#{team.custodian.full_name} #{team.custodian.email}"}
+                  %td
+                    %span.user__name
+                      = team.custodian.full_name
+                  %td= team.custodian.email
+                  %td
+                    - team.registers.each do |register|
+                      %span.user__register-name= prepare_register_name(register.key)
+                  %td
+                    = link_to 'View team', team_path(team)
 
     #invites.js-tab-pane.tab-pane
       %table
@@ -51,13 +52,14 @@
             %th Email
             %th Registers
         %tbody
-          - if @pending_custodians.present?
-            - @pending_custodians.each do |custodian|
-              %tr{class: "js-filter-item", "data-filter-terms" => "#{custodian.try(:full_name)} #{custodian.email}"}
-                %td= custodian.email
-                %td
-                  - custodian.team_members.first.team.registers.each do |register|
-                    %span.user__register-name= prepare_register_name(register.key)
+          - if @teams.present?
+            - @teams.each do |team|
+              - if team.custodian.invitation_accepted_at.nil?
+                %tr{class: "js-filter-item", "data-filter-terms" => "#{team.custodian.email}"}
+                  %td= team.custodian.email
+                  %td
+                    - team.registers.each do |register|
+                      %span.user__register-name= prepare_register_name(register.key)
 
 = content_for :javascript do
   :javascript


### PR DESCRIPTION
Fixes #155 

Before we were displaying users who were custodians and a link to their team but if a custodian had more than one team then this wouldn’t work so now we are rendering all the teams and displaying the custodian details with a view team link.