### PR TITLE
deploy master to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,16 @@ before_deploy:
   - travis_retry cf install-plugin autopilot -f -r CF-Community
 
 deploy:
-  provider: script
-  script: ./bin/deploy staging
-  skip_cleanup: true
-  on:
-    repo: openregister/managing-registers
-    branch: master
+  - provider: script
+    script: ./bin/deploy production
+    skip_cleanup: true
+    on:
+      repo: openregister/managing-registers
+      branch: master
+  - provider: script
+    script: ./bin/deploy staging
+    skip_cleanup: true
+    on:
+      repo: openregister/managing-registers
+      branch: staging   
+    

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the service used primarily by register custodians to manage their registers. You can find out more information about registers or contact us [here](https://registers.cloudapps.digital/).
 
+## Running locally
+
 ### 1. Prerequisites
 Ruby 2.4.2
 Postgres 9.5+
@@ -17,6 +19,17 @@ Postgres 9.5+
 
 ### 5 Run further migrations of the Database
 `rake db:migrate`
+
+## Deployment
+`managing-registers` uses continuous deployment, all code pushed to the `master` branch will be automatically deployment to production.
+### Testing your changes
+You have two options if you wish to test your changes on the staging environment:
+1. Push your code to the `staging` branch which will be automatically deployed to the `staging` environment *or*
+1. Deploy your branch locally by installing [autopilot](https://github.com/contraband/autopilot) then running: 
+``` 
+cf target -s sandbox
+cf zero-downtime-push managing-registers -f manifest-staging.yml
+```
 
 
 ## License


### PR DESCRIPTION
* Deploy `master` branch to `production` environment.
* Adds option to deploy to `staging` by deploying to `staging` branch (suggestion by @arnau)