### PR TITLE
set CF_SPACE in deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   global:
   - CF_API="https://api.cloud.service.gov.uk"
   - CF_ORG="openregister"
-  - CF_SPACE="sandbox"
   - CF_USERNAME="register-design-authority@digital.cabinet-office.gov.uk"
 
 services:

--- a/bin/deploy
+++ b/bin/deploy
@@ -4,6 +4,12 @@ set -e
 # Default to staging but overridable by argument
 ENVIRONMENT=${1:-staging}
 
+if [ $ENVIRONMENT = "production" ]; then
+    CF_SPACE="production"
+else
+    CF_SPACE="sandbox"
+fi
+
 # Parse app name from manifest to ensure it matches up
 APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest-base.yml'); puts config['applications'][0]['name']")
 


### PR DESCRIPTION
We need to vary the `CF_SPACE` based on the deployment target, so this PR moves the setting of this variable to the `bin/deploy` script.