### PR TITLE
use symbol instead of string for phase in production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: 'https://managing-registers.cloudapps.digital' }
 
-  config.register_phase = 'https://register.beta.openregister.org/'
+  config.register_phase = :beta
   config.register_url = 'beta.openregister.org/load-rsf'
   config.register_ssl = true
 


### PR DESCRIPTION
### Context
Fixes exception when calling [download_rsf](https://github.com/openregister/openregister-ruby-client/blob/f4d9a9918b7afedc86e8f283820ee6b7b79835c2/lib/register_client.rb#L71-L73) from within Managing registers as that function is expecting a symbol rather than a string for the phase. Also, the symbol will resolve to the same host, as per this behaviour in the client library: https://github.com/openregister/openregister-ruby-client/blob/f4d9a9918b7afedc86e8f283820ee6b7b79835c2/lib/openregister.rb#L270

### Changes proposed in this pull request
Change production config to use symbol rather than string for phase.

### Guidance to review
See links to related code above