### PR TITLE
move google analytics ID into config & stringify

### DIFF
--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -6,7 +6,7 @@
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-ga('create', <%= Rails.application.secrets.google_analytics_tracking_id %>, 'auto');
+ga('create', '<%= Rails.configuration.google_analytics_tracking_id %>', 'auto');
 ga('set', 'anonymizeIp', true);
 ga('set', 'displayFeaturesTask', null);
 ga('set', 'transport', 'beacon');

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,4 +100,5 @@ Rails.application.configure do
   config.register_ssl = true
 
   config.cache_duration = 3600
+  config.google_analytics_tracking_id = 'UA-86101042-5'
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -91,6 +91,7 @@ Rails.application.configure do
   config.register_phase = :test
   config.register_url = 'test.openregister.org/load-rsf'
   config.register_ssl = true
+  config.google_analytics_tracking_id = 'UA-86101042-6'
 
   config.cache_duration = 3600
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -39,7 +39,6 @@ staging:
   notify_custodian_invite_template: <%= ENV["NOTIFY_CUSTODIAN_INVITE_TEMPLATE"] %>
   notify_advanced_invite_template: <%= ENV["NOTIFY_ADVANCED_INVITE_TEMPLATE"] %>
   notify_basic_invite_template: <%= ENV["NOTIFY_BASIC_INVITE_TEMPLATE"] %>
-  google_analytics_tracking_id: <%= ENV['UA_TRACKING_ID'] %>
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
@@ -50,4 +49,3 @@ production:
   notify_custodian_invite_template: <%= ENV["NOTIFY_CUSTODIAN_INVITE_TEMPLATE"] %>
   notify_advanced_invite_template: <%= ENV["NOTIFY_ADVANCED_INVITE_TEMPLATE"] %>
   notify_basic_invite_template: <%= ENV["NOTIFY_BASIC_INVITE_TEMPLATE"] %>
-  google_analytics_tracking_id: <%= ENV['UA_TRACKING_ID'] %>

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -6,7 +6,6 @@ routes:
   - route: managing-registers-production.cloudapps.digital
   - route: managing-registers.cloudapps.digital
 env:
-  UA_TRACKING_ID: 'UA-86101042-5'
   RAILS_ENV: production
   RACK_ENV: production
 services:

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -9,4 +9,3 @@ services:
 env:
   RAILS_ENV: staging
   RACK_ENV: staging
-  UA_TRACKING_ID: 'UA-86101042-6'


### PR DESCRIPTION
### Context
We were throwing client-side errors on production because the Google Analytics ID was not being set as a string. In addition we were setting the value from the CF manifest which was unnecessary and inconsistent with other config.

### Changes proposed in this pull request
* Set google analytics ID as a string
* Move config value out of manifest and into application config

### Guidance to review
go to: https://managing-registers-staging.cloudapps.digital/
You should see GA value being set correctly and no JS errors. You cannot test this locally as the partial is only added on staging and production.
<img width="264" alt="screen shot 2017-11-29 at 10 57 01" src="https://user-images.githubusercontent.com/1764158/33372852-60477532-d4f7-11e7-8ce5-0e76f4d9431e.png">
