### PR TITLE
do not use unicode in RSF JSON

### DIFF
--- a/app/services/create_rsf.rb
+++ b/app/services/create_rsf.rb
@@ -4,7 +4,7 @@ class CreateRsf
     current_date_register_format = DateTime.now.strftime("%Y-%m-%dT%H:%M:%SZ")
     record_key = payload[register_name]
 
-    item = "add-item\t#{payload.to_json}"
+    item = "add-item\t#{JSON::dump(payload)}"
     entry = "append-entry\tuser\t#{record_key}\t#{current_date_register_format}\tsha-256:#{payload_sha}"
 
     "#{item}\n#{entry}"

--- a/spec/helpers/create_rsf_spec.rb
+++ b/spec/helpers/create_rsf_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe CreateRsf do
+  payload = { "country" => "Foo & Bar" }
+  describe 'RSF encoding' do
+    it 'preserves literal characters' do
+      rsf = CreateRsf.call(payload, 'country')
+      expect rsf.to include("Foo & Bar")
+    end
+  end
+end

--- a/spec/helpers/create_rsf_spec.rb
+++ b/spec/helpers/create_rsf_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe CreateRsf do
   describe 'RSF encoding' do
     it 'preserves literal characters' do
       rsf = CreateRsf.call(payload, 'country')
-      expect rsf.to include("Foo & Bar")
+      expect(rsf).to include('Foo & Bar')
     end
   end
 end


### PR DESCRIPTION
### Context
Register updates containing special characters were failing when POSTed to ORJ because the JSON serialiser was converting special characters to their Unicode equivalents as a CSRF protection measure [[Stack Overflow discussion]](https://stackoverflow.com/q/17936318/238230).  
```
rails console
{foo: 'hello &  world'}.to_json
 => "{\"foo\":\"hello \\u0026  world\"}" 
```

However, the registers spec says:
> All other characters MUST be included literally (ie unescaped). This includes forward-slash (/)

### Changes proposed in this pull request
Use a JSON serialiser variant which does not unicode encode special characters within the RSF.

### Guidance to review
Attempt an update containing a special character e.g. `&`.