### PR TITLE
redirect after POST failure

### DIFF
--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -120,12 +120,13 @@ private
       rsf_body = CreateRsf.call(@change.payload, @change.register_name)
       Rails.env.development? || response = RegisterPost.call(@change.register_name, rsf_body)
 
-      if Rails.env.development? || Rails.env.staging? || response.code == '200'
+      if Rails.env.development? || response.code == '200'
         @registers_client.get_register(@change.register_name, Rails.configuration.register_phase.to_s).refresh_data
         flash[:notice] = 'The record has been published.'
         redirect_to controller: 'register', action: 'index', register: params[:register]
       else
-        flash[:alert] = 'This update hasn’t been approved due to technical reasons. Please try again.'
+        flash[:alert] = 'This update hasn’t been published due to technical reasons. Please try again.'
+        redirect_back fallback_location: root_path
       end
     else
       register_name = params[:register].downcase


### PR DESCRIPTION
### Context
The user was seeing a silent failure if the POST failed to ORJ, as we were not redirecting in this case, so the server responded with ` POST 206` and the browser showed no change.

### Changes proposed in this pull request
Redirect following POST failure

### Guidance to review
When POST fails, user should see a message: 
<img width="1007" alt="screen shot 2017-11-30 at 10 11 08" src="https://user-images.githubusercontent.com/1764158/33425509-d35d9e10-d5b6-11e7-9ce6-3275c55034e9.png">

