### PR TITLE
update client library version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
 
 # Ruby client for OpenRegisters
-gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby-client', tag: 'v0.2.2'
+gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby-client', tag: 'v0.2.3'
 
 # Email and Text Notifications
 gem 'govuk_notify_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/openregister/openregister-ruby-client
-  revision: 025bcdab86dfcb4c81659ca580a815dd122d3026
-  tag: v0.2.2
+  revision: f4d9a9918b7afedc86e8f283820ee6b7b79835c2
+  tag: v0.2.3
   specs:
-    openregister-ruby (0.2.2)
+    openregister-ruby (0.2.3)
       mini_cache (~> 1.1.0)
       morph (~> 0.5.0)
       rest-client (~> 2)


### PR DESCRIPTION
### Context
bump client library version to https://github.com/openregister/openregister-ruby-client/releases/tag/v0.2.3

### Changes proposed in this pull request
bump client library version 

### Guidance to review
Should see update when you do `bundle install`