### PR TITLE
Fix SHA computation

### DIFF
--- a/app/services/create_rsf.rb
+++ b/app/services/create_rsf.rb
@@ -1,10 +1,11 @@
 class CreateRsf
   def self.call(payload, register_name)
-    payload_sha = Digest::SHA256.hexdigest payload.to_json
+    payload_json = JSON::dump(payload)
+    payload_sha = Digest::SHA256.hexdigest(payload_json)
     current_date_register_format = DateTime.now.strftime("%Y-%m-%dT%H:%M:%SZ")
     record_key = payload[register_name]
 
-    item = "add-item\t#{JSON::dump(payload)}"
+    item = "add-item\t#{payload_json}"
     entry = "append-entry\tuser\t#{record_key}\t#{current_date_register_format}\tsha-256:#{payload_sha}"
 
     "#{item}\n#{entry}"

--- a/spec/helpers/create_rsf_spec.rb
+++ b/spec/helpers/create_rsf_spec.rb
@@ -5,5 +5,9 @@ RSpec.describe CreateRsf do
       rsf = CreateRsf.call(payload, 'country')
       expect(rsf).to include('Foo & Bar')
     end
+    it 'correctly computes hash' do
+      rsf = CreateRsf.call(payload, 'country')
+      expect(rsf).to include(Digest::SHA256.hexdigest('{"country":"Foo & Bar"}'))
+    end
   end
 end


### PR DESCRIPTION
### Context
POSTs containing special characters were failing as we were computing the SHA based on the Unicode version.

### Changes proposed in this pull request
Compute the SHA based on the non-unicode version

### Guidance to review
Attempt an update on staging using a special character e.g. `&`. 
