### PR TITLE
rename register param to not conflict with register field

### DIFF
--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -9,31 +9,30 @@ class RegisterController < ApplicationController
 
   def index
     check_permissions(:REGISTER_INDEX, current_user: current_user,
-                                      register_name: params[:register])
+                                      register_name: params[:register_id])
 
     @changes = Change.joins('LEFT OUTER JOIN statuses on statuses.change_id = changes.id')
-                     .where("register_name = '#{params[:register]}' AND statuses.status = 'pending'")
+                     .where("register_name = '#{params[:register_id]}' AND statuses.status = 'pending'")
 
-    @register = get_register(params[:register])
+    @register = get_register(params[:register_id])
                 ._all_records
                 .sort_by(&:key)
   end
 
   def new
     check_permissions(:REGISTER_NEW, current_user: current_user,
-                                    register_name: params[:register])
+                                    register_name: params[:register_id])
 
-    @register = get_register(params[:register])
+    @register = get_register(params[:register_id])
     @form = JSON.parse(params.to_json)
   end
 
   def edit
     check_permissions(:REGISTER_EDIT, current_user: current_user,
-                                     register_name: params[:register])
-
+                                     register_name: params[:register_id])
     @changes = Change.joins('LEFT OUTER JOIN statuses on statuses.change_id = changes.id')
-                     .where("register_name = '#{params[:register]}' AND statuses.status = 'pending'")
-    @register = get_register(params[:register])
+                     .where("register_name = '#{params[:register_id]}' AND statuses.status = 'pending'")
+    @register = get_register(params[:register_id])
 
     if @changes.any? { |c| c.payload.value?(params[:id]) }
       flash[:notice] = 'There is already a pending update on this record, this must be reviewed before creating another update'
@@ -42,16 +41,16 @@ class RegisterController < ApplicationController
 
     if @form.nil?
       @form = convert_register_json(
-        OpenRegister.record(params[:register].downcase, params[:id], Rails.configuration.register_phase)
+        OpenRegister.record(params[:register_id].downcase, params[:id], Rails.configuration.register_phase)
       )
     end
   end
 
   def confirm
     check_permissions(:REGISTER_CONFIRM, current_user: current_user,
-                                        register_name: params[:register])
+                                        register_name: params[:register_id])
 
-    register_name = params[:register].downcase
+    register_name = params[:register_id].downcase
     field_definitions = @registers_client.get_register(register_name, 'beta').get_field_definitions
     records = @registers_client.get_register(register_name, 'beta').get_records
     validation_result = @data_validator.get_form_errors(params, field_definitions, register_name, records)
@@ -70,13 +69,12 @@ class RegisterController < ApplicationController
       if @current_register_record
         @current_register_record = convert_register_json(@current_register_record)
       end
-
       render :confirm
     end
   end
 
   def create
-    fields = get_register(params[:register]).fields
+    fields = get_register(params[:register_id]).fields
     payload = generate_canonical_object(fields, params)
 
     if current_user.basic?
@@ -90,13 +88,13 @@ private
 
   def create_pending_review(payload)
     check_permissions(:REGISTER_CREATE_PENDING_REVIEW, current_user: current_user,
-                                                      register_name: params[:register])
+                                                      register_name: params[:register_id])
 
-    @change = Change.new(register_name: params[:register], payload: payload, user_id: current_user.id)
+    @change = Change.new(register_name: params[:register_id], payload: payload, user_id: current_user.id)
     @change.status = Status.new(status: 'pending')
     @change.save
 
-    @change_approvers = Register.find_by(key: params[:register]).team.team_members.where.not(role: 'basic', user_id: current_user)
+    @change_approvers = Register.find_by(key: params[:register_id]).team.team_members.where.not(role: 'basic', user_id: current_user)
 
     if @change_approvers.present?
       RegisterUpdatesMailer.register_update_notification(@change, current_user, @change_approvers).deliver_now
@@ -105,15 +103,15 @@ private
     RegisterUpdatesMailer.register_update_receipt(@change, current_user).deliver_now
 
     flash[:notice] = 'Your update has been submitted and sent for review.'
-    redirect_to action: 'index', register: params[:register]
+    redirect_to action: 'index', register: params[:register_id]
   end
 
   def create_and_review(payload)
     check_permissions(:REGISTER_CREATE_AND_REVIEW, current_user: current_user,
-                                                  register_name: params[:register])
+                                                  register_name: params[:register_id])
 
     if params[:confirm_approve] == '1'
-      @change = Change.new(register_name: params[:register], payload: payload, user_id: current_user.id)
+      @change = Change.new(register_name: params[:register_id], payload: payload, user_id: current_user.id)
       @change.status = Status.new(status: 'approved', reviewed_by_id: current_user.id)
       @change.save
 
@@ -123,14 +121,14 @@ private
       if Rails.env.development? || response.code == '200'
         @registers_client.get_register(@change.register_name, Rails.configuration.register_phase.to_s).refresh_data
         flash[:notice] = 'The record has been published.'
-        redirect_to controller: 'register', action: 'index', register: params[:register]
+        redirect_to controller: 'register', action: 'index', register: params[:register_id]
       else
         flash[:alert] = 'This update hasn’t been published due to technical reasons. Please try again.'
         redirect_back fallback_location: root_path
       end
     else
-      register_name = params[:register].downcase
-      @register = get_register(params[:register])
+      register_name = params[:register_id].downcase
+      @register = get_register(params[:register_id])
       @current_register_record = OpenRegister.record(register_name, params[register_name.to_sym], :beta)
 
       if @current_register_record

--- a/app/views/change/edit.html.haml
+++ b/app/views/change/edit.html.haml
@@ -1,5 +1,5 @@
 = content_for :page_title, 'Review updates'
-= link_to 'Back', "/#{params[:register]}", class: 'link-back'
+= link_to 'Back', "/#{params[:register_id]}", class: 'link-back'
 
 - if params[:approve] == 'yes'
   %header.page-header
@@ -10,7 +10,7 @@
   = form_tag change_path, method: :put do
     .multiple-choice
       = check_box_tag 'confirm_approve'
-      = label_tag 'confirm_approve', "These updates will be published to the #{params[:register]} register."
+      = label_tag 'confirm_approve', "These updates will be published to the #{params[:register_id]} register."
     .form-group
       = submit_tag 'Approve', class: 'button'
 

--- a/app/views/change/show.html.haml
+++ b/app/views/change/show.html.haml
@@ -1,5 +1,5 @@
 = content_for :page_title, 'Review updates'
-= link_to 'Back', "/#{params[:register]}", class: 'link-back'
+= link_to 'Back', "/#{params[:register_id]}", class: 'link-back'
 
 %header.page-header
   %h1.heading-large Review updates

--- a/app/views/register/confirm.html.haml
+++ b/app/views/register/confirm.html.haml
@@ -39,7 +39,7 @@
               %td
                 %div.panel.panel-change-notification #{params[field.to_sym]}
               %td
-                = link_to 'Update', {action: 'edit', id: params[params[:register].to_sym], anchor: field, params: params}
+                = link_to 'Update', {action: 'edit', id: params[params[:register_id].to_sym], anchor: field, params: params}
             - else
               %td
               %td
@@ -58,8 +58,8 @@
             %td
             %td
 
-= form_for :create, method: :post, url: "/#{params[:register]}" do
-  = hidden_field_tag :register_name, params[:register]
+= form_for :create, method: :post, url: "/#{params[:register_id]}" do
+  = hidden_field_tag :register_name, params[:register_id]
   = hidden_field_tag :data_confirmed, true
   - @register.fields.each do |field|
     = hidden_field_tag field, params[field]
@@ -76,6 +76,6 @@
         %span.error-message= flash.alert
       .multiple-choice
         = check_box_tag :confirm_approve
-        = label_tag :confirm_approve, "These updates will be published to the #{params[:register].capitalize} register."
+        = label_tag :confirm_approve, "These updates will be published to the #{params[:register_id].capitalize} register."
   .form-group
     = button_tag 'Submit', class: 'button'

--- a/app/views/register/edit.html.haml
+++ b/app/views/register/edit.html.haml
@@ -1,5 +1,5 @@
-= content_for :page_title, "Edit #{params[:register]}"
-= link_to 'Back', "/#{params[:register]}", class: 'link-back'
+= content_for :page_title, "Edit #{params[:register_id]}"
+= link_to 'Back', "/#{params[:register_id]}", class: 'link-back'
 
 %h1.heading-large Update a record
 

--- a/app/views/register/index.html.haml
+++ b/app/views/register/index.html.haml
@@ -3,7 +3,7 @@
 %header.page-header
   .grid-row
     .column-two-thirds
-      %h1.heading-large #{prepare_register_name(params[:register])} register
+      %h1.heading-large #{prepare_register_name(params[:register_id])} register
     .column-one-third
       = link_to "Add a new record", new_register_path, class: "button align-with-heading"
 
@@ -28,7 +28,7 @@
           %table
             %thead
               %tr
-                %th #{params[:register].capitalize}
+                %th #{params[:register_id].capitalize}
                 - if @register[0].try(:name)
                   %th Name
                 %th
@@ -37,7 +37,7 @@
             %tbody
               - @changes.each do |change|
                 %tr
-                  %td= change.payload[params[:register].to_s]
+                  %td= change.payload[params[:register_id].to_s]
                   %td= change.payload['name']
                   %td= link_to 'Review', "/change/#{change.id}"
         - else

--- a/app/views/register/new.html.haml
+++ b/app/views/register/new.html.haml
@@ -1,5 +1,5 @@
-= content_for :page_title, "New #{params[:register]}"
-= link_to 'Back', "/#{params[:register]}", class: 'link-back'
+= content_for :page_title, "New #{params[:register_id]}"
+= link_to 'Back', "/#{params[:register_id]}", class: 'link-back'
 
 = render partial: 'layouts/form-error-summary' if flash.present?
 

--- a/app/views/register/shared/_form.html.haml
+++ b/app/views/register/shared/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for :create, url: "/#{params[:register]}" do |f|
+= form_for :create, url: "/#{params[:register_id]}" do |f|
   - if params[:action] == 'new' || params[:action] == 'create'
     = hidden_field_tag 'is_create', 'true'
   - @register.fields.each do |field|
@@ -9,8 +9,8 @@
         - if has_error
           %span{class: 'error-message'} #{flash[field.underscore]}
       %span.form-hint #{get_description_for_register_field(field)}
-      - if params[:action] == 'edit' && field == params[:register]
-        = text_field_tag field, field != params[:register] ? @form[field] : @form['key'], class: 'form-control disabled', readonly: true, tabindex: '-1'
+      - if params[:action] == 'edit' && field == params[:register_id]
+        = text_field_tag field, field != params[:register_id] ? @form[field] : @form['key'], class: 'form-control disabled', readonly: true, tabindex: '-1'
       - else
         = text_field_tag field, @form[field], class: "form-control #{'form-control-error' if has_error}"
   = f.submit 'Continue', class: 'button'

--- a/app/views/register/shared/_records.html.haml
+++ b/app/views/register/shared/_records.html.haml
@@ -8,7 +8,7 @@
 %table
   %thead
     %tr
-      %th #{params[:register].capitalize}
+      %th #{params[:register_id].capitalize}
       - if @register[0].try(:name)
         %th Name
       %th

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,9 +23,9 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/:register', to: 'register#index', as: 'registers'
-  get '/:register/:id/edit', to: 'register#edit', as: 'edit_register'
-  get '/:register/new', to: 'register#new', as: 'new_register'
-  post '/:register', to: 'register#create'
+  get '/:register_id', to: 'register#index', as: 'registers'
+  get '/:register_id/:id/edit', to: 'register#edit', as: 'edit_register'
+  get '/:register_id/new', to: 'register#new', as: 'new_register'
+  post '/:register_id', to: 'register#create'
 
 end


### PR DESCRIPTION
### Context
We rely on `params` in the POST to update items. However, we were also using the param `register` in routing for the register primary key. This caused a bug when the POST for an update contained a field named `register` this user input was replaced with the already existing param `register`.  

### Changes proposed in this pull request
Rename the `register` param in routes to `register_id`

### Guidance to review
Create an update in a register with a field named `register` e.g. `statistical-geography` the user input for the field named `register` should be preserved.