### PR TITLE
Add missing rails version to migration

### DIFF
--- a/db/migrate/20170502094348_devise_invitable_add_to_users.rb
+++ b/db/migrate/20170502094348_devise_invitable_add_to_users.rb
@@ -1,4 +1,4 @@
-class DeviseInvitableAddToUsers < ActiveRecord::Migration
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[5.0]
   def up
     change_table :users do |t|
       t.string     :invitation_token

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,77 +15,78 @@ ActiveRecord::Schema.define(version: 20171025090217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "changes", force: :cascade do |t|
-    t.json     "payload"
-    t.string   "register_name"
-    t.integer  "user_id"
+  create_table "changes", id: :serial, force: :cascade do |t|
+    t.json "payload"
+    t.string "register_name"
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["user_id"], name: "index_changes_on_user_id", using: :btree
+    t.index ["user_id"], name: "index_changes_on_user_id"
   end
 
-  create_table "registers", force: :cascade do |t|
-    t.string   "key",        null: false
-    t.integer  "team_id"
+  create_table "registers", id: :serial, force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "team_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_registers_on_key", unique: true, using: :btree
-    t.index ["team_id"], name: "index_registers_on_team_id", using: :btree
+    t.index ["key"], name: "index_registers_on_key", unique: true
+    t.index ["team_id"], name: "index_registers_on_team_id"
   end
 
-  create_table "statuses", force: :cascade do |t|
-    t.string  "status"
-    t.string  "comment"
+  create_table "statuses", id: :serial, force: :cascade do |t|
+    t.string "status"
+    t.string "comment"
     t.integer "reviewed_by_id"
-    t.integer "change_id",      null: false
-    t.index ["change_id"], name: "index_statuses_on_change_id", using: :btree
-    t.index ["reviewed_by_id"], name: "index_statuses_on_reviewed_by_id", using: :btree
+    t.integer "change_id", null: false
+    t.index ["change_id"], name: "index_statuses_on_change_id"
+    t.index ["reviewed_by_id"], name: "index_statuses_on_reviewed_by_id"
   end
 
-  create_table "team_members", force: :cascade do |t|
-    t.string   "role"
-    t.integer  "team_id"
-    t.integer  "user_id"
+  create_table "team_members", id: :serial, force: :cascade do |t|
+    t.string "role"
+    t.integer "team_id"
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["team_id"], name: "index_team_members_on_team_id", using: :btree
-    t.index ["user_id"], name: "index_team_members_on_user_id", using: :btree
+    t.index ["team_id"], name: "index_team_members_on_team_id"
+    t.index ["user_id"], name: "index_team_members_on_user_id"
   end
 
-  create_table "teams", force: :cascade do |t|
+  create_table "teams", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.string   "invitation_token"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
     t.datetime "invitation_accepted_at"
-    t.integer  "invitation_limit"
-    t.string   "invited_by_type"
-    t.integer  "invited_by_id"
-    t.integer  "invitations_count",      default: 0
-    t.string   "full_name"
-    t.boolean  "admin",                  default: false
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["full_name"], name: "index_users_on_full_name", using: :btree
-    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
-    t.index ["invitations_count"], name: "index_users_on_invitations_count", using: :btree
-    t.index ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.integer "invited_by_id"
+    t.integer "invitations_count", default: 0
+    t.string "full_name"
+    t.boolean "admin", default: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["full_name"], name: "index_users_on_full_name"
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invitations_count"], name: "index_users_on_invitations_count"
+    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "changes", "users"


### PR DESCRIPTION
### Changes proposed in this pull request
Add rails version to `DeviseInvitableAddToUsers ` 

### Guidance to review
Check setup from a fresh clone -
```bash
$ bundle install
$ rake db:create
$ rake db:migrate
$ rails server
```