### PR TITLE
Update routes

### DIFF
--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -3,7 +3,6 @@
 inherit: manifest-base.yml
 
 routes:
-  - route: managing-registers-production.cloudapps.digital
   - route: manage.registers.service.gov.uk
 env:
   RAILS_ENV: production

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -4,7 +4,7 @@ inherit: manifest-base.yml
 
 routes:
   - route: managing-registers-production.cloudapps.digital
-  - route: managing-registers.cloudapps.digital
+  - route: manage.registers.service.gov.uk
 env:
   RAILS_ENV: production
   RACK_ENV: production


### PR DESCRIPTION
### Context
The manage.registers.service.gov.uk route is now the primary route for the managing-registers app. The managing-registers.cloudapps.digital route is now mapped to an app that redirects to manage.registers.service.gov.uk.

### Changes proposed in this pull request
Remove managing-registers.cloudapps.digital and add manage.registers.service.gov.uk route.

### Guidance to review
managing-registers.cloudapps.digital should redirect to manage.registers.service.gov.uk.