### PR TITLE
Revert "add prometheus service"

### DIFF
--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -12,4 +12,3 @@ applications:
 services:
    - managing-registers-environment-variables
    - logit-ssl-drain
-   - prometheus


### PR DESCRIPTION
### Context
App level metrics are not working due to:
1) not having gds_metrics gem
2) being blocked by devise authentication

### Changes proposed in this pull request
Revert binding so we can stop errors in prometheus scraper and investigate the issues i

### Guidance to review
errors should stop in prometheus after deploy
